### PR TITLE
fix: plug resource leaks in GTK PopupManager error paths

### DIFF
--- a/src/apprt/gtk/PopupManager.zig
+++ b/src/apprt/gtk/PopupManager.zig
@@ -162,7 +162,6 @@ pub const PopupManager = struct {
             log.warn("failed to allocate popup profile name: {}", .{err});
             return false;
         };
-        errdefer self.alloc.free(name_z);
 
         // Create a new window with is-popup=true
         const win = gobject.ext.newInstance(Window, .{
@@ -176,12 +175,15 @@ pub const PopupManager = struct {
         // Track the window
         self.window_names.append(self.alloc, name_z) catch |err| {
             log.warn("failed to track popup window name: {}", .{err});
+            self.alloc.free(name_z);
+            win.as(gtk.Window).destroy();
             return false;
         };
         self.window_ptrs.append(self.alloc, win) catch |err| {
             log.warn("failed to track popup window: {}", .{err});
             const popped_name = self.window_names.pop();
             self.alloc.free(popped_name);
+            win.as(gtk.Window).destroy();
             return false;
         };
 


### PR DESCRIPTION
## Summary
- Removed a dead `errdefer` in `createAndShow()` that never fired (function returns `bool`, not an error — `catch` blocks use `return false` which is a normal return, not error propagation)
- Added explicit `self.alloc.free(name_z)` and `win.as(gtk.Window).destroy()` cleanup in the `window_names.append` catch block
- Added explicit `win.as(gtk.Window).destroy()` cleanup in the `window_ptrs.append` catch block (name cleanup was already handled via pop+free)

## Test plan
- [x] `zig build -Demit-macos-app=false` compiles cleanly
- [ ] GTK-only code path — no automated tests available; manual testing on Linux required

🤖 Generated with [Claude Code](https://claude.com/claude-code)