### PR TITLE
fix: append popup action enum values at end for ABI compatibility

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -641,6 +641,11 @@ typedef struct {
   const char* title;
 } ghostty_action_set_title_s;
 
+// apprt.action.PopupAction.C
+typedef struct {
+  const char* name;
+} ghostty_action_popup_s;
+
 // apprt.action.PromptTitle
 typedef enum {
   GHOSTTY_PROMPT_TITLE_SURFACE,
@@ -921,6 +926,9 @@ typedef enum {
   GHOSTTY_ACTION_SEARCH_SELECTED,
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+  GHOSTTY_ACTION_TOGGLE_POPUP,
+  GHOSTTY_ACTION_SHOW_POPUP,
+  GHOSTTY_ACTION_HIDE_POPUP,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -962,6 +970,9 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
+  ghostty_action_popup_s toggle_popup;
+  ghostty_action_popup_s show_popup;
+  ghostty_action_popup_s hide_popup;
 } ghostty_action_u;
 
 typedef struct {

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -343,6 +343,15 @@ pub const Action = union(Key) {
     /// otherwise the terminal-set title.
     copy_title_to_clipboard,
 
+    /// Toggle a named popup terminal visibility.
+    toggle_popup: PopupAction,
+
+    /// Show a named popup terminal (create if needed, no-op if visible).
+    show_popup: PopupAction,
+
+    /// Hide a named popup terminal.
+    hide_popup: PopupAction,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -410,6 +419,9 @@ pub const Action = union(Key) {
         search_selected,
         readonly,
         copy_title_to_clipboard,
+        toggle_popup,
+        show_popup,
+        hide_popup,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -712,6 +724,29 @@ pub const SetTitle = struct {
         writer: *std.Io.Writer,
     ) !void {
         try writer.print("{s}{{ {s} }}", .{ @typeName(@This()), value.title });
+    }
+};
+
+/// Payload for popup actions (toggle, show, hide).
+/// Sync with: ghostty_action_popup_s
+pub const PopupAction = struct {
+    name: [:0]const u8,
+
+    pub const C = extern struct {
+        name: [*:0]const u8,
+    };
+
+    pub fn cval(self: PopupAction) C {
+        return .{ .name = self.name.ptr };
+    }
+
+    pub fn format(
+        value: @This(),
+        comptime _: []const u8,
+        _: std.fmt.FormatOptions,
+        writer: *std.Io.Writer,
+    ) !void {
+        try writer.print("{s}{{ {s} }}", .{ @typeName(@This()), value.name });
     }
 };
 


### PR DESCRIPTION
## Summary
- Moved `toggle_popup`, `show_popup`, `hide_popup` action entries to the end of the `Action` union, `Key` enum (action.zig), and `ghostty_action_tag_e` enum (ghostty.h)
- Added `PopupAction` payload type and `ghostty_action_popup_s` C struct
- Fixes ABI breakage: inserting mid-enum shifts all subsequent discriminant values, breaking C consumers

## Test plan
- [x] `zig build test -Dtest-filter="ghostty.h Action.Key"` passes (validates Zig enum matches ghostty.h)
- [x] `zig build -Demit-macos-app=false` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)