### PR TITLE
[codex] Fix popup issues (#7, #8, #10, #12)

### DIFF
--- a/src/apprt/gtk/PopupManager.zig
+++ b/src/apprt/gtk/PopupManager.zig
@@ -21,25 +21,19 @@ const log = std.log.scoped(.popup_manager);
 /// The manager tracks which windows exist for each profile and handles
 /// the toggle/show/hide lifecycle.
 pub const PopupManager = struct {
+    const WindowEntry = struct {
+        name: [:0]const u8,
+        weak_ref: WeakRef(Window) = .empty,
+        stale: bool = false,
+
+        fn deinit(self: *const WindowEntry, alloc: Allocator) void {
+            alloc.free(self.name);
+        }
+    };
+
     alloc: Allocator,
-
-    /// Popup profile names (owned copies from config).
-    profile_names: std.ArrayListUnmanaged([:0]const u8) = .empty,
-
-    /// Popup profile data, parallel to profile_names.
-    profiles: std.ArrayListUnmanaged(popupmod.PopupProfile) = .empty,
-
-    /// Tracked popup window instances. Each entry stores the owned name
-    /// (sentinel-terminated) and a weak reference to the Window. We use a
-    /// simple parallel-array approach to avoid hashmap key ownership complexity.
-    /// WeakRef ensures we don't hold dangling pointers when windows are
-    /// destroyed externally (e.g., user closes window, GTK shutdown order).
-    window_names: std.ArrayListUnmanaged([:0]const u8) = .empty,
-    window_refs: std.ArrayListUnmanaged(WeakRef(Window)) = .empty,
-    /// Parallel to window_names/window_refs: true if the profile config
-    /// changed since the window was created. Stale windows are destroyed
-    /// and recreated on next toggle when hidden.
-    window_stale: std.ArrayListUnmanaged(bool) = .empty,
+    profiles: std.ArrayListUnmanaged(popupmod.NamedProfile) = .empty,
+    windows: std.ArrayListUnmanaged(WindowEntry) = .empty,
 
     pub fn init(alloc: Allocator) PopupManager {
         return .{
@@ -48,97 +42,49 @@ pub const PopupManager = struct {
     }
 
     pub fn deinit(self: *PopupManager) void {
-        for (self.profile_names.items) |name| self.alloc.free(name);
-        for (self.profiles.items) |profile| {
-            if (profile.keybind) |kb| self.alloc.free(kb);
-            if (profile.command) |cmd| self.alloc.free(cmd);
-            if (profile.cwd) |cwd| self.alloc.free(cwd);
-        }
-        self.profile_names.deinit(self.alloc);
+        for (self.profiles.items) |entry| entry.deinit(self.alloc);
         self.profiles.deinit(self.alloc);
 
-        for (self.window_names.items) |name| self.alloc.free(name);
-        self.window_names.deinit(self.alloc);
-        self.window_refs.deinit(self.alloc);
-        self.window_stale.deinit(self.alloc);
+        for (self.windows.items) |entry| entry.deinit(self.alloc);
+        self.windows.deinit(self.alloc);
     }
 
     /// Load popup profiles from the config. This replaces any previously
     /// stored profiles. It does NOT destroy existing windows -- those will
     /// be lazily cleaned up on next toggle/show/hide.
     pub fn loadConfig(self: *PopupManager, config: *const configpkg.Config) void {
-        // Free old name strings AND profile string fields since we own them
-        for (self.profile_names.items) |name| self.alloc.free(name);
-        for (self.profiles.items) |profile| {
-            if (profile.keybind) |kb| self.alloc.free(kb);
-            if (profile.command) |cmd| self.alloc.free(cmd);
-            if (profile.cwd) |cwd| self.alloc.free(cwd);
-        }
-        self.profile_names.clearRetainingCapacity();
+        for (self.profiles.items) |entry| entry.deinit(self.alloc);
         self.profiles.clearRetainingCapacity();
 
-        for (config.popup.names.items, config.popup.profiles.items) |name, profile| {
-            const duped = self.alloc.dupeZ(u8, name) catch |err| {
-                log.warn("failed to duplicate popup profile name: {}", .{err});
+        for (config.popup.entries.items) |entry| {
+            const cloned = popupmod.NamedProfile.init(
+                self.alloc,
+                entry.named_profile.name,
+                entry.named_profile.profile,
+            ) catch |err| {
+                log.warn("failed to duplicate popup profile '{s}': {}", .{
+                    entry.named_profile.name,
+                    err,
+                });
                 continue;
             };
 
-            // Deep-copy the profile so we own the string fields (cwd, command).
-            // The config may be freed after loadConfig returns, so borrowing
-            // slices from it would be a use-after-free.
-            var owned_profile = profile;
-            if (profile.command) |cmd| {
-                owned_profile.command = self.alloc.dupe(u8, cmd) catch |err| {
-                    log.warn("failed to duplicate popup command: {}", .{err});
-                    self.alloc.free(duped);
-                    continue;
-                };
-            }
-            if (profile.cwd) |cwd| {
-                owned_profile.cwd = self.alloc.dupe(u8, cwd) catch |err| {
-                    log.warn("failed to duplicate popup cwd: {}", .{err});
-                    if (owned_profile.command) |cmd| self.alloc.free(cmd);
-                    self.alloc.free(duped);
-                    continue;
-                };
-            }
-            if (profile.keybind) |kb| {
-                owned_profile.keybind = self.alloc.dupe(u8, kb) catch |err| {
-                    log.warn("failed to duplicate popup keybind: {}", .{err});
-                    if (owned_profile.command) |cmd| self.alloc.free(cmd);
-                    if (owned_profile.cwd) |cwd| self.alloc.free(cwd);
-                    self.alloc.free(duped);
-                    continue;
-                };
-            }
-
-            self.profile_names.append(self.alloc, duped) catch |err| {
-                log.warn("failed to store popup profile name: {}", .{err});
-                if (owned_profile.keybind) |kb| self.alloc.free(kb);
-                if (owned_profile.command) |cmd| self.alloc.free(cmd);
-                if (owned_profile.cwd) |cwd| self.alloc.free(cwd);
-                self.alloc.free(duped);
-                continue;
-            };
-            self.profiles.append(self.alloc, owned_profile) catch |err| {
-                log.warn("failed to store popup profile: {}", .{err});
-                if (self.profile_names.pop()) |popped| {
-                    const plain: []const u8 = popped;
-                    self.alloc.free(plain);
-                }
-                if (owned_profile.keybind) |kb| self.alloc.free(kb);
-                if (owned_profile.command) |cmd| self.alloc.free(cmd);
-                if (owned_profile.cwd) |cwd| self.alloc.free(cwd);
+            self.profiles.append(self.alloc, cloned) catch |err| {
+                log.warn("failed to store popup profile '{s}': {}", .{
+                    entry.named_profile.name,
+                    err,
+                });
+                cloned.deinit(self.alloc);
                 continue;
             };
         }
 
-        log.debug("loaded {} popup profiles", .{self.profile_names.items.len});
+        log.debug("loaded {} popup profiles", .{self.profiles.items.len});
     }
 
     /// Toggle a popup by name: create+show if not exists, show if hidden,
     /// hide if visible.
-    pub fn toggle(self: *PopupManager, name: []const u8) bool {
+    pub fn toggle(self: *PopupManager, name: []const u8, inherited_cwd: ?[:0]const u8) bool {
         if (self.findValidWindow(name)) |win| {
             defer win.unref();
             const widget = win.as(gtk.Widget);
@@ -148,7 +94,7 @@ pub const PopupManager = struct {
                 // If stale (config changed), destroy and recreate
                 if (self.isWindowStale(name)) {
                     self.destroyWindow(name);
-                    return self.createAndShow(name);
+                    return self.createAndShow(name, inherited_cwd);
                 }
                 widget.setVisible(1);
                 gtk.Window.present(win.as(gtk.Window));
@@ -156,12 +102,12 @@ pub const PopupManager = struct {
             }
         }
 
-        return self.createAndShow(name);
+        return self.createAndShow(name, inherited_cwd);
     }
 
     /// Show a popup by name: create+show if not exists, show if hidden,
     /// no-op if already visible.
-    pub fn show(self: *PopupManager, name: []const u8) bool {
+    pub fn show(self: *PopupManager, name: []const u8, inherited_cwd: ?[:0]const u8) bool {
         if (self.findValidWindow(name)) |win| {
             defer win.unref();
             const widget = win.as(gtk.Widget);
@@ -169,21 +115,21 @@ pub const PopupManager = struct {
             // If stale (config changed), destroy and recreate
             if (self.isWindowStale(name)) {
                 self.destroyWindow(name);
-                return self.createAndShow(name);
+                return self.createAndShow(name, inherited_cwd);
             }
             widget.setVisible(1);
             gtk.Window.present(win.as(gtk.Window));
             return true;
         }
 
-        return self.createAndShow(name);
+        return self.createAndShow(name, inherited_cwd);
     }
 
     /// Hide a popup by name. If persist=false in the profile, destroy
     /// the window instead of just hiding it.
     pub fn hide(self: *PopupManager, name: []const u8) bool {
         const idx = self.findWindowIndex(name) orelse return false;
-        const win = self.window_refs.items[idx].get() orelse {
+        const win = self.windows.items[idx].weak_ref.get() orelse {
             // Window was destroyed externally, clean up the stale entry.
             self.removeWindowAt(idx);
             return false;
@@ -213,14 +159,12 @@ pub const PopupManager = struct {
     pub fn updateProfileConfigs(self: *PopupManager, config: *const configpkg.Config) void {
         // 1. Destroy windows for truly removed profiles only
         var i: usize = 0;
-        while (i < self.window_names.items.len) {
-            const wname = self.window_names.items[i];
-            const still_exists = for (config.popup.names.items) |cname| {
-                if (std.mem.eql(u8, wname, cname)) break true;
-            } else false;
+        while (i < self.windows.items.len) {
+            const wname = self.windows.items[i].name;
+            const still_exists = config.popup.get(wname) != null;
 
             if (!still_exists) {
-                if (self.window_refs.items[i].get()) |win| {
+                if (self.windows.items[i].weak_ref.get()) |win| {
                     defer win.unref();
                     win.as(gtk.Window).destroy();
                 }
@@ -236,8 +180,8 @@ pub const PopupManager = struct {
         // 2. Mark existing windows as stale — they'll be destroyed and
         //    recreated on next toggle if hidden, or kept alive if visible
         //    until the user toggles them.
-        for (self.window_names.items) |wname| {
-            self.markStaleIfChanged(wname, config);
+        for (self.windows.items) |window_entry| {
+            self.markStaleIfChanged(window_entry.name, config);
         }
 
         // 3. Reload stored profiles from new config
@@ -246,20 +190,18 @@ pub const PopupManager = struct {
 
     /// Hide (or destroy) all popup windows. Called during quit.
     pub fn hideAll(self: *PopupManager) void {
-        for (self.window_refs.items) |*ref| {
-            if (ref.get()) |win| {
+        for (self.windows.items) |window_entry| {
+            if (window_entry.weak_ref.get()) |win| {
                 defer win.unref();
                 win.as(gtk.Window).destroy();
             }
         }
-        for (self.window_names.items) |name| self.alloc.free(name);
-        self.window_names.clearRetainingCapacity();
-        self.window_refs.clearRetainingCapacity();
-        self.window_stale.clearRetainingCapacity();
+        for (self.windows.items) |window_entry| window_entry.deinit(self.alloc);
+        self.windows.clearRetainingCapacity();
     }
 
     /// Create a new popup window and show it.
-    fn createAndShow(self: *PopupManager, name: []const u8) bool {
+    fn createAndShow(self: *PopupManager, name: []const u8, inherited_cwd: ?[:0]const u8) bool {
         // Get the GIO application (which is our GhosttyApplication)
         const gio_app = gio.Application.getDefault() orelse {
             log.warn("no default application available for popup creation", .{});
@@ -297,28 +239,12 @@ pub const PopupManager = struct {
         var weak_ref: WeakRef(Window) = .empty;
         weak_ref.set(win);
 
-        self.window_names.append(self.alloc, name_z) catch |err| {
-            log.warn("failed to track popup window name: {}", .{err});
+        self.windows.append(self.alloc, .{
+            .name = name_z,
+            .weak_ref = weak_ref,
+        }) catch |err| {
+            log.warn("failed to track popup window: {}", .{err});
             self.alloc.free(name_z);
-            win.as(gtk.Window).destroy();
-            return false;
-        };
-        self.window_refs.append(self.alloc, weak_ref) catch |err| {
-            log.warn("failed to track popup window ref: {}", .{err});
-            if (self.window_names.pop()) |popped_name| {
-                const plain: []const u8 = popped_name;
-                self.alloc.free(plain);
-            }
-            win.as(gtk.Window).destroy();
-            return false;
-        };
-        self.window_stale.append(self.alloc, false) catch |err| {
-            log.warn("failed to track popup stale flag: {}", .{err});
-            if (self.window_names.pop()) |popped_name| {
-                const plain: []const u8 = popped_name;
-                self.alloc.free(plain);
-            }
-            _ = self.window_refs.pop();
             win.as(gtk.Window).destroy();
             return false;
         };
@@ -332,48 +258,17 @@ pub const PopupManager = struct {
             .{},
         );
 
-        // Resolve working directory: explicit cwd > focused surface pwd > none.
-        // Track ownership so we only free allocations we made (not borrows from
-        // surface.getPwd() which is managed by the surface).
-        var wd_owned: bool = false;
-        const working_directory: ?[:0]const u8 = wd: {
-            if (profile.cwd) |cwd| {
-                wd_owned = true;
-                // Only expand bare ~ or ~/... (not ~otheruser)
-                if (cwd.len == 1 and cwd[0] == '~' or
-                    (cwd.len > 1 and cwd[0] == '~' and cwd[1] == '/'))
-                {
-                    if (std.posix.getenv("HOME")) |home| {
-                        break :wd std.fmt.allocPrintSentinel(
-                            self.alloc,
-                            "{s}{s}",
-                            .{ home, cwd[1..] },
-                            0,
-                        ) catch break :wd null;
-                    }
-                }
-                break :wd self.alloc.dupeZ(u8, cwd) catch break :wd null;
-            }
-            // Try to inherit from focused surface (borrowed, not owned)
-            const list = gtk.Window.listToplevels();
-            defer list.free();
-            var node_: ?*glib.List = list;
-            while (node_) |node| : (node_ = node.f_next) {
-                const gtk_window: *gtk.Window = @ptrCast(@alignCast(node.f_data orelse continue));
-                if (gtk_window.isActive() == 0) continue;
-                const ghostty_win = gobject.ext.cast(Window, gtk_window) orelse continue;
-                const surface = ghostty_win.getActiveSurface() orelse continue;
-                break :wd surface.getPwd();
-            }
-            break :wd null;
-        };
-        defer if (wd_owned) {
-            if (working_directory) |wd| self.alloc.free(wd);
-        };
+        const working_directory = popupmod.resolveWorkingDirectory(
+            self.alloc,
+            profile.cwd,
+            inherited_cwd,
+            std.posix.getenv("HOME"),
+        ) catch .{};
+        defer working_directory.deinit(self.alloc);
 
         // Create initial tab
         win.newTabForWindow(null, .{
-            .working_directory = working_directory,
+            .working_directory = working_directory.path,
             .background_opacity = profile.opacity,
             .window_padding_color = .extend,
         });
@@ -420,7 +315,7 @@ pub const PopupManager = struct {
     /// window doesn't exist or was destroyed externally.
     fn findValidWindow(self: *PopupManager, name: []const u8) ?*Window {
         const idx = self.findWindowIndex(name) orelse return null;
-        const win = self.window_refs.items[idx].get() orelse {
+        const win = self.windows.items[idx].weak_ref.get() orelse {
             // Window was destroyed externally, clean up the stale entry.
             self.removeWindowAt(idx);
             return null;
@@ -429,25 +324,21 @@ pub const PopupManager = struct {
     }
 
     fn findWindowIndex(self: *const PopupManager, name: []const u8) ?usize {
-        for (self.window_names.items, 0..) |n, i| {
-            if (std.mem.eql(u8, n, name)) return i;
+        for (self.windows.items, 0..) |window_entry, i| {
+            if (std.mem.eql(u8, window_entry.name, name)) return i;
         }
         return null;
     }
 
     fn removeWindowAt(self: *PopupManager, idx: usize) void {
-        const name = self.window_names.orderedRemove(idx);
-        _ = self.window_refs.orderedRemove(idx);
-        _ = self.window_stale.orderedRemove(idx);
-        // Cast sentinel-terminated slice to plain slice for Allocator.free
-        const plain: []const u8 = name;
-        self.alloc.free(plain);
+        const window_entry = self.windows.orderedRemove(idx);
+        window_entry.deinit(self.alloc);
     }
 
     /// Check if a tracked window is marked stale (config changed since creation).
     fn isWindowStale(self: *const PopupManager, name: []const u8) bool {
         const idx = self.findWindowIndex(name) orelse return false;
-        return self.window_stale.items[idx];
+        return self.windows.items[idx].stale;
     }
 
     /// Mark a window stale if its profile differs from the new config.
@@ -458,29 +349,9 @@ pub const PopupManager = struct {
         const win_idx = self.findWindowIndex(name) orelse return;
         const old_profile = self.getProfile(name) orelse return;
 
-        // Find the new profile in config
-        for (config.popup.names.items, config.popup.profiles.items) |cname, new_profile| {
-            if (std.mem.eql(u8, name, cname)) {
-                // Compare all fields — non-string enums/ints/bools
-                if (old_profile.position != new_profile.position or
-                    old_profile.anchor != new_profile.anchor or
-                    !optionalDimensionEqual(old_profile.x, new_profile.x) or
-                    !optionalDimensionEqual(old_profile.y, new_profile.y) or
-                    old_profile.width.value != new_profile.width.value or
-                    old_profile.width.unit != new_profile.width.unit or
-                    old_profile.height.value != new_profile.height.value or
-                    old_profile.height.unit != new_profile.height.unit or
-                    old_profile.autohide != new_profile.autohide or
-                    old_profile.persist != new_profile.persist or
-                    !optionalF64Equal(old_profile.opacity, new_profile.opacity) or
-                    !optionalSliceEqual(old_profile.command, new_profile.command) or
-                    !optionalSliceEqual(old_profile.cwd, new_profile.cwd) or
-                    !optionalSliceEqual(old_profile.keybind, new_profile.keybind))
-                {
-                    self.window_stale.items[win_idx] = true;
-                    return;
-                }
-                return; // Not changed
+        if (config.popup.get(name)) |new_profile| {
+            if (popupmod.profileChanged(old_profile, new_profile)) {
+                self.windows.items[win_idx].stale = true;
             }
         }
     }
@@ -488,7 +359,7 @@ pub const PopupManager = struct {
     /// Destroy a tracked popup window by name.
     fn destroyWindow(self: *PopupManager, name: []const u8) void {
         const idx = self.findWindowIndex(name) orelse return;
-        if (self.window_refs.items[idx].get()) |win| {
+        if (self.windows.items[idx].weak_ref.get()) |win| {
             defer win.unref();
             win.as(gtk.Window).destroy();
         }
@@ -496,27 +367,9 @@ pub const PopupManager = struct {
     }
 
     fn getProfile(self: *const PopupManager, name: []const u8) ?popupmod.PopupProfile {
-        for (self.profile_names.items, self.profiles.items) |n, p| {
-            if (std.mem.eql(u8, n, name)) return p;
+        for (self.profiles.items) |entry| {
+            if (std.mem.eql(u8, entry.name, name)) return entry.profile;
         }
         return null;
     }
 };
-
-fn optionalDimensionEqual(a: ?popupmod.Dimension, b: ?popupmod.Dimension) bool {
-    if (a == null and b == null) return true;
-    if (a == null or b == null) return false;
-    return a.?.value == b.?.value and a.?.unit == b.?.unit;
-}
-
-fn optionalSliceEqual(a: ?[]const u8, b: ?[]const u8) bool {
-    if (a == null and b == null) return true;
-    if (a == null or b == null) return false;
-    return std.mem.eql(u8, a.?, b.?);
-}
-
-fn optionalF64Equal(a: ?f64, b: ?f64) bool {
-    if (a == null and b == null) return true;
-    if (a == null or b == null) return false;
-    return a.? == b.?;
-}

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -771,17 +771,21 @@ pub const Application = extern struct {
 
             .toggle_maximize => Action.toggleMaximize(target),
             .toggle_fullscreen => Action.toggleFullscreen(target),
-            .toggle_quick_terminal => return Action.toggleQuickTerminal(self),
+            .toggle_quick_terminal => return Action.toggleQuickTerminal(self, target),
             .toggle_popup => {
                 const priv = self.private();
                 if (!priv.winproto.supportsPopup()) return false;
-                if (priv.popup_manager) |*pm| return pm.toggle(value.name);
+                if (priv.popup_manager) |*pm| {
+                    return pm.toggle(value.name, Action.targetWorkingDirectory(target));
+                }
                 return false;
             },
             .show_popup => {
                 const priv = self.private();
                 if (!priv.winproto.supportsPopup()) return false;
-                if (priv.popup_manager) |*pm| return pm.show(value.name);
+                if (priv.popup_manager) |*pm| {
+                    return pm.show(value.name, Action.targetWorkingDirectory(target));
+                }
                 return false;
             },
             .hide_popup => {
@@ -2734,12 +2738,21 @@ const Action = struct {
         }
     }
 
-    pub fn toggleQuickTerminal(self: *Application) bool {
+    fn targetWorkingDirectory(target: apprt.Target) ?[:0]const u8 {
+        return switch (target) {
+            .app => null,
+            .surface => |v| v.rt_surface.surface.getPwd(),
+        };
+    }
+
+    pub fn toggleQuickTerminal(self: *Application, target: apprt.Target) bool {
         const priv = self.private();
         if (!priv.winproto.supportsPopup()) return false;
 
         // Delegate to the popup manager using the "quick" profile name.
-        if (priv.popup_manager) |*pm| return pm.toggle(popupmod.quick_profile_name);
+        if (priv.popup_manager) |*pm| {
+            return pm.toggle(popupmod.quick_profile_name, targetWorkingDirectory(target));
+        }
 
         // Fallback: if popup manager isn't initialized, use legacy path.
         if (getQuickTerminalWindow()) |win| {

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2740,9 +2740,23 @@ const Action = struct {
 
     fn targetWorkingDirectory(target: apprt.Target) ?[:0]const u8 {
         return switch (target) {
-            .app => null,
+            .app => activeSurfaceWorkingDirectory(),
             .surface => |v| v.rt_surface.surface.getPwd(),
         };
+    }
+
+    fn activeSurfaceWorkingDirectory() ?[:0]const u8 {
+        const glist = gtk.Window.listToplevels();
+        defer glist.free();
+
+        const focused = @as(?*glib.List, glist.findCustom(
+            null,
+            findActiveWindow,
+        )) orelse return null;
+        const gtk_window: *gtk.Window = @ptrCast(@alignCast(focused.f_data orelse return null));
+        const window = gobject.ext.cast(Window, gtk_window) orelse return null;
+        const surface = window.getActiveSurface() orelse return null;
+        return surface.getPwd();
     }
 
     pub fn toggleQuickTerminal(self: *Application, target: apprt.Target) bool {

--- a/src/apprt/popup.zig
+++ b/src/apprt/popup.zig
@@ -110,6 +110,107 @@ pub const PopupProfile = struct {
     }
 };
 
+/// An owned popup profile paired with its name.
+pub const NamedProfile = struct {
+    name: [:0]const u8,
+    profile: PopupProfile,
+
+    pub fn init(alloc: std.mem.Allocator, name: []const u8, profile: PopupProfile) !NamedProfile {
+        const owned_name = try alloc.dupeZ(u8, name);
+        errdefer alloc.free(owned_name);
+        return .{
+            .name = owned_name,
+            .profile = try cloneProfile(profile, alloc),
+        };
+    }
+
+    pub fn clone(self: NamedProfile, alloc: std.mem.Allocator) !NamedProfile {
+        return .{
+            .name = try alloc.dupeZ(u8, self.name),
+            .profile = try cloneProfile(self.profile, alloc),
+        };
+    }
+
+    pub fn deinit(self: *const NamedProfile, alloc: std.mem.Allocator) void {
+        alloc.free(self.name);
+        freeProfileStrings(self.profile, alloc);
+    }
+};
+
+pub const ResolvedWorkingDirectory = struct {
+    path: ?[:0]const u8 = null,
+    owned: bool = false,
+
+    pub fn deinit(self: ResolvedWorkingDirectory, alloc: std.mem.Allocator) void {
+        if (!self.owned) return;
+        if (self.path) |path| alloc.free(path);
+    }
+};
+
+pub fn resolveWorkingDirectory(
+    alloc: std.mem.Allocator,
+    explicit_cwd: ?[]const u8,
+    inherited_cwd: ?[:0]const u8,
+    home: ?[]const u8,
+) !ResolvedWorkingDirectory {
+    const cwd = explicit_cwd orelse return .{ .path = inherited_cwd };
+    if ((cwd.len == 1 and cwd[0] == '~') or
+        (cwd.len > 1 and cwd[0] == '~' and cwd[1] == '/'))
+    {
+        if (home) |home_dir| {
+            return .{
+                .path = try std.fmt.allocPrintSentinel(
+                    alloc,
+                    "{s}{s}",
+                    .{ home_dir, cwd[1..] },
+                    0,
+                ),
+                .owned = true,
+            };
+        }
+    }
+
+    return .{
+        .path = try alloc.dupeZ(u8, cwd),
+        .owned = true,
+    };
+}
+
+pub fn profileChanged(old: PopupProfile, new: PopupProfile) bool {
+    return old.position != new.position or
+        old.anchor != new.anchor or
+        !optionalDimensionEqual(old.x, new.x) or
+        !optionalDimensionEqual(old.y, new.y) or
+        old.width.value != new.width.value or
+        old.width.unit != new.width.unit or
+        old.height.value != new.height.value or
+        old.height.unit != new.height.unit or
+        old.autohide != new.autohide or
+        old.persist != new.persist or
+        !optionalF64Equal(old.opacity, new.opacity) or
+        !optionalSliceEqual(old.command, new.command) or
+        !optionalSliceEqual(old.cwd, new.cwd) or
+        !optionalSliceEqual(old.keybind, new.keybind);
+}
+
+pub fn cloneProfile(profile: PopupProfile, alloc: std.mem.Allocator) !PopupProfile {
+    var cloned = profile;
+    if (profile.keybind) |keybind| cloned.keybind = try alloc.dupe(u8, keybind);
+    errdefer if (cloned.keybind) |keybind| alloc.free(keybind);
+
+    if (profile.command) |command| cloned.command = try alloc.dupe(u8, command);
+    errdefer if (cloned.command) |command| alloc.free(command);
+
+    if (profile.cwd) |cwd| cloned.cwd = try alloc.dupe(u8, cwd);
+    return cloned;
+}
+
+pub fn freeProfileStrings(profile: PopupProfile, alloc: std.mem.Allocator) void {
+    if (profile.keybind) |keybind| alloc.free(keybind);
+    if (profile.command) |command| alloc.free(command);
+    if (profile.cwd) |cwd| alloc.free(cwd);
+}
+
 /// Validate a popup profile name.
 /// Allowed characters: [a-zA-Z0-9_-], must be non-empty.
 pub fn isValidName(name: []const u8) bool {
@@ -181,4 +282,83 @@ test "PopupProfile.C: opacity passes through" {
     const p = PopupProfile{ .opacity = 0.8 };
     const c = p.cval(null, null);
     try std.testing.expectEqual(@as(f64, 0.8), c.opacity);
+}
+
+test "resolveWorkingDirectory prefers explicit cwd over inherited cwd" {
+    const testing = std.testing;
+    const resolved = try resolveWorkingDirectory(
+        testing.allocator,
+        "~/projects/trident",
+        "/tmp/inherited",
+        "/Users/tester",
+    );
+    defer resolved.deinit(testing.allocator);
+
+    try testing.expect(resolved.owned);
+    try testing.expectEqualStrings("/Users/tester/projects/trident", resolved.path.?);
+}
+
+test "resolveWorkingDirectory falls back to inherited cwd" {
+    const testing = std.testing;
+    const inherited: [:0]const u8 = "/tmp/inherited";
+    const resolved = try resolveWorkingDirectory(testing.allocator, null, inherited, null);
+
+    try testing.expect(!resolved.owned);
+    try testing.expectEqualStrings(inherited, resolved.path.?);
+}
+
+test "resolveWorkingDirectory keeps literal tilde when home is unavailable" {
+    const testing = std.testing;
+    const resolved = try resolveWorkingDirectory(testing.allocator, "~/projects/trident", null, null);
+    defer resolved.deinit(testing.allocator);
+
+    try testing.expect(resolved.owned);
+    try testing.expectEqualStrings("~/projects/trident", resolved.path.?);
+}
+
+test "profileChanged detects hot reload relevant field changes" {
+    const base = PopupProfile{
+        .width = Dimension.initPercent(80),
+        .height = Dimension.initPercent(40),
+        .command = "echo hello",
+        .cwd = "/tmp",
+        .keybind = "ctrl+grave_accent",
+        .opacity = 0.5,
+    };
+
+    try std.testing.expect(!profileChanged(base, base));
+    try std.testing.expect(profileChanged(base, .{
+        .width = Dimension.initPercent(90),
+        .height = base.height,
+        .command = base.command,
+        .cwd = base.cwd,
+        .keybind = base.keybind,
+        .opacity = base.opacity,
+    }));
+    try std.testing.expect(profileChanged(base, .{
+        .width = base.width,
+        .height = base.height,
+        .command = "echo updated",
+        .cwd = base.cwd,
+        .keybind = base.keybind,
+        .opacity = base.opacity,
+    }));
+}
+
+fn optionalDimensionEqual(a: ?Dimension, b: ?Dimension) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return a.?.value == b.?.value and a.?.unit == b.?.unit;
+}
+
+fn optionalSliceEqual(a: ?[]const u8, b: ?[]const u8) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return std.mem.eql(u8, a.?, b.?);
+}
+
+fn optionalF64Equal(a: ?f64, b: ?f64) bool {
+    if (a == null and b == null) return true;
+    if (a == null or b == null) return false;
+    return a.? == b.?;
 }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -9365,6 +9365,7 @@ pub const RepeatablePopup = struct {
             remainder,
             null,
         );
+        defer popupmod.freeProfileStrings(profile, alloc);
         if (profile.opacity) |o| {
             profile.opacity = std.math.clamp(o, 0.0, 1.0);
         }
@@ -11557,6 +11558,25 @@ test "popup: opacity is clamped during CLI parsing" {
     if (high) |p| {
         try testing.expectEqual(@as(?f64, 1.0), p.opacity);
     }
+}
+
+test "popup: parseCLI transfers parsed string ownership without leaks" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var popups: RepeatablePopup = .{};
+    defer popups.deinit(alloc);
+
+    try popups.parseCLI(
+        alloc,
+        "demo:width:80%,height:50%,command:echo hello,cwd:~/tmp,keybind:ctrl+grave_accent",
+    );
+
+    try testing.expectEqual(@as(usize, 1), popups.entries.items.len);
+    const profile = popups.get("demo").?;
+    try testing.expectEqualStrings("echo hello", profile.command.?);
+    try testing.expectEqualStrings("~/tmp", profile.cwd.?);
+    try testing.expectEqualStrings("ctrl+grave_accent", profile.keybind.?);
 }
 
 test "popup: upsert rolls back on allocation failure" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4913,23 +4913,7 @@ pub fn migrateQuickTerminalToPopup(self: *Config, alloc: Allocator) !void {
         },
     }
 
-    const name_z = try alloc.dupeZ(u8, popupmod.quick_profile_name);
-    try self.popup.names.append(alloc, name_z);
-    try self.popup.profiles.append(alloc, profile);
-
-    // Keep C-view arrays in sync (mirroring parseCLI pattern).
-    try self.popup.names_c.append(alloc, name_z.ptr);
-    const cmd_z: ?[*:0]const u8 = if (profile.command) |cmd|
-        (try alloc.dupeZ(u8, cmd)).ptr
-    else
-        null;
-    const cwd_z: ?[*:0]const u8 = if (profile.cwd) |cwd|
-        (try alloc.dupeZ(u8, cwd)).ptr
-    else
-        null;
-    try self.popup.commands_z.append(alloc, cmd_z);
-    try self.popup.cwd_z.append(alloc, cwd_z);
-    try self.popup.profiles_c.append(alloc, profile.cval(cmd_z, cwd_z));
+    try self.popup.upsert(alloc, popupmod.quick_profile_name, profile);
 }
 
 /// Convert a legacy QuickTerminalSize.Size to a popup Dimension.
@@ -4970,7 +4954,9 @@ pub fn synthesizePopupKeybinds(self: *Config, alloc: Allocator) !void {
     var popup_binds: std.ArrayListUnmanaged(PopupBind) = .empty;
 
     // First pass: collect all popup bindings; last definition wins.
-    for (self.popup.names.items, self.popup.profiles.items) |name, profile| {
+    for (self.popup.entries.items) |entry| {
+        const name = entry.named_profile.name;
+        const profile = entry.named_profile.profile;
         const keybind_str = profile.keybind orelse continue;
 
         // Build the full binding string, e.g. "ctrl+grave_accent=toggle_popup:quick"
@@ -9287,20 +9273,53 @@ pub const RepeatableCommand = struct {
 pub const RepeatablePopup = struct {
     const Self = @This();
 
-    names: std.ArrayListUnmanaged([:0]const u8) = .empty,
-    profiles: std.ArrayListUnmanaged(popupmod.PopupProfile) = .empty,
+    const Entry = struct {
+        named_profile: popupmod.NamedProfile,
+        c_profile: popupmod.PopupProfile.C,
+        command_z: ?[*:0]const u8 = null,
+        cwd_z: ?[*:0]const u8 = null,
 
-    /// Parallel C-API arrays, maintained in sync with names/profiles.
+        fn init(alloc: Allocator, name: []const u8, profile: popupmod.PopupProfile) !Entry {
+            var entry: Entry = .{
+                .named_profile = try .init(alloc, name, profile),
+                .c_profile = undefined,
+            };
+            errdefer entry.named_profile.deinit(alloc);
+
+            if (entry.named_profile.profile.command) |command| {
+                entry.command_z = (try alloc.dupeZ(u8, command)).ptr;
+            }
+            errdefer if (entry.command_z) |command| alloc.free(std.mem.sliceTo(command, 0));
+
+            if (entry.named_profile.profile.cwd) |cwd| {
+                entry.cwd_z = (try alloc.dupeZ(u8, cwd)).ptr;
+            }
+            errdefer if (entry.cwd_z) |cwd| alloc.free(std.mem.sliceTo(cwd, 0));
+
+            entry.syncCProfile();
+            return entry;
+        }
+
+        fn clone(self: Entry, alloc: Allocator) !Entry {
+            return init(alloc, self.named_profile.name, self.named_profile.profile);
+        }
+
+        fn deinit(self: *const Entry, alloc: Allocator) void {
+            self.named_profile.deinit(alloc);
+            if (self.command_z) |command| alloc.free(std.mem.sliceTo(command, 0));
+            if (self.cwd_z) |cwd| alloc.free(std.mem.sliceTo(cwd, 0));
+        }
+
+        fn syncCProfile(self: *Entry) void {
+            self.c_profile = self.named_profile.profile.cval(self.command_z, self.cwd_z);
+        }
+    };
+
+    entries: std.ArrayListUnmanaged(Entry) = .empty,
+
+    /// Derived C-API arrays, maintained in sync with entries.
     names_c: std.ArrayListUnmanaged([*:0]const u8) = .empty,
     profiles_c: std.ArrayListUnmanaged(popupmod.PopupProfile.C) = .empty,
-
-    /// Sentinel-terminated copies of command strings for the C API.
-    /// Indexed in parallel with names/profiles; null when no command.
-    commands_z: std.ArrayListUnmanaged(?[*:0]const u8) = .empty,
-
-    /// Sentinel-terminated copies of CWD paths for the C API.
-    /// Indexed in parallel with names/profiles; null when no cwd.
-    cwd_z: std.ArrayListUnmanaged(?[*:0]const u8) = .empty,
 
     /// ghostty_config_popup_list_s
     pub const C = extern struct {
@@ -9324,31 +9343,10 @@ pub const RepeatablePopup = struct {
     ) !void {
         const input = input_ orelse "";
         if (input.len == 0) {
-            // Free all owned strings before clearing arrays.
-            for (self.names.items) |name| alloc.free(name);
-            for (self.profiles.items) |profile| {
-                if (profile.keybind) |kb| alloc.free(kb);
-                if (profile.command) |cmd| alloc.free(cmd);
-                if (profile.cwd) |cwd| alloc.free(cwd);
-            }
-            for (self.commands_z.items) |cmd_z| {
-                if (cmd_z) |ptr| {
-                    const slice = std.mem.sliceTo(ptr, 0);
-                    alloc.free(slice);
-                }
-            }
-            for (self.cwd_z.items) |cz| {
-                if (cz) |ptr| {
-                    const slice = std.mem.sliceTo(ptr, 0);
-                    alloc.free(slice);
-                }
-            }
-            self.names.clearRetainingCapacity();
-            self.profiles.clearRetainingCapacity();
+            for (self.entries.items) |entry| entry.deinit(alloc);
+            self.entries.clearRetainingCapacity();
             self.names_c.clearRetainingCapacity();
             self.profiles_c.clearRetainingCapacity();
-            self.commands_z.clearRetainingCapacity();
-            self.cwd_z.clearRetainingCapacity();
             return;
         }
 
@@ -9371,58 +9369,49 @@ pub const RepeatablePopup = struct {
             profile.opacity = std.math.clamp(o, 0.0, 1.0);
         }
 
-        // Create sentinel-terminated copy of the command for C API.
-        const cmd_z: ?[*:0]const u8 = if (profile.command) |cmd|
-            (try alloc.dupeZ(u8, cmd)).ptr
-        else
-            null;
+        try self.upsert(alloc, name_raw, profile);
+    }
 
-        // Create sentinel-terminated copy of the cwd for C API.
-        const cwd_z_val: ?[*:0]const u8 = if (profile.cwd) |cwd|
-            (try alloc.dupeZ(u8, cwd)).ptr
-        else
-            null;
+    pub fn upsert(
+        self: *Self,
+        alloc: Allocator,
+        name: []const u8,
+        profile: popupmod.PopupProfile,
+    ) !void {
+        if (!popupmod.isValidName(name)) return error.InvalidValue;
 
-        const name = try alloc.dupeZ(u8, name_raw);
+        var entry = try Entry.init(alloc, name, profile);
+        var entry_owned = true;
+        errdefer if (entry_owned) entry.deinit(alloc);
 
         // Last definition wins: if a popup with this name already
         // exists, replace its profile instead of appending a duplicate.
-        for (self.names.items, 0..) |existing, i| {
-            if (std.mem.eql(u8, existing, name_raw)) {
-                // Free old profile strings before overwriting.
-                if (self.profiles.items[i].keybind) |kb| alloc.free(kb);
-                if (self.profiles.items[i].command) |cmd| alloc.free(cmd);
-                if (self.profiles.items[i].cwd) |old_cwd| alloc.free(old_cwd);
-                if (self.commands_z.items[i]) |old_cmd| {
-                    const slice = std.mem.sliceTo(old_cmd, 0);
-                    alloc.free(slice);
-                }
-                if (self.cwd_z.items[i]) |old_cwd_z| {
-                    const slice = std.mem.sliceTo(old_cwd_z, 0);
-                    alloc.free(slice);
-                }
-                // Free the new name since we're not using it.
-                alloc.free(name);
-                self.profiles.items[i] = profile;
-                self.commands_z.items[i] = cmd_z;
-                self.cwd_z.items[i] = cwd_z_val;
-                self.profiles_c.items[i] = profile.cval(cmd_z, cwd_z_val);
+        for (self.entries.items, 0..) |*existing, i| {
+            if (std.mem.eql(u8, existing.named_profile.name, name)) {
+                const old_entry = existing.*;
+                existing.* = entry;
+                entry_owned = false;
+                self.names_c.items[i] = entry.named_profile.name.ptr;
+                self.profiles_c.items[i] = entry.c_profile;
+                old_entry.deinit(alloc);
                 return;
             }
         }
 
-        try self.names.append(alloc, name);
-        try self.profiles.append(alloc, profile);
-        try self.names_c.append(alloc, name.ptr);
-        try self.profiles_c.append(alloc, profile.cval(cmd_z, cwd_z_val));
-        try self.commands_z.append(alloc, cmd_z);
-        try self.cwd_z.append(alloc, cwd_z_val);
+        try self.entries.append(alloc, entry);
+        entry_owned = false;
+        errdefer if (self.entries.pop()) |rolled_back| rolled_back.deinit(alloc);
+
+        try self.names_c.append(alloc, entry.named_profile.name.ptr);
+        errdefer _ = self.names_c.pop();
+
+        try self.profiles_c.append(alloc, entry.c_profile);
     }
 
     /// Look up a popup profile by name.
     pub fn get(self: *const Self, name: []const u8) ?popupmod.PopupProfile {
-        for (self.names.items, 0..) |n, i| {
-            if (std.mem.eql(u8, n, name)) return self.profiles.items[i];
+        for (self.entries.items) |entry| {
+            if (std.mem.eql(u8, entry.named_profile.name, name)) return entry.named_profile.profile;
         }
         return null;
     }
@@ -9431,65 +9420,20 @@ pub const RepeatablePopup = struct {
     pub fn clone(self: *const Self, alloc: Allocator) !Self {
         var new: Self = .{};
         errdefer new.deinit(alloc);
-        for (self.names.items) |name| {
-            const duped = try alloc.dupeZ(u8, name);
-            try new.names.append(alloc, duped);
-            try new.names_c.append(alloc, duped.ptr);
-        }
-        for (self.profiles.items) |profile| {
-            var cloned_profile = profile;
-            // Deep-copy string fields so the clone doesn't alias source memory.
-            if (profile.keybind) |kb| {
-                cloned_profile.keybind = try alloc.dupe(u8, kb);
-            }
-            if (profile.command) |cmd| {
-                cloned_profile.command = try alloc.dupe(u8, cmd);
-            }
-            if (profile.cwd) |cwd| {
-                cloned_profile.cwd = try alloc.dupe(u8, cwd);
-            }
-            try new.profiles.append(alloc, cloned_profile);
-            // Re-create sentinel-terminated command copy for the clone.
-            const new_cmd_z: ?[*:0]const u8 = if (cloned_profile.command) |cmd|
-                (try alloc.dupeZ(u8, cmd)).ptr
-            else
-                null;
-            const new_cwd_z: ?[*:0]const u8 = if (cloned_profile.cwd) |cwd|
-                (try alloc.dupeZ(u8, cwd)).ptr
-            else
-                null;
-            try new.commands_z.append(alloc, new_cmd_z);
-            try new.cwd_z.append(alloc, new_cwd_z);
-            try new.profiles_c.append(alloc, cloned_profile.cval(new_cmd_z, new_cwd_z));
+        for (self.entries.items) |entry| {
+            const cloned = try entry.clone(alloc);
+            try new.entries.append(alloc, cloned);
+            try new.names_c.append(alloc, cloned.named_profile.name.ptr);
+            try new.profiles_c.append(alloc, cloned.c_profile);
         }
         return new;
     }
 
     pub fn deinit(self: *Self, alloc: Allocator) void {
-        for (self.names.items) |name| alloc.free(name);
-        for (self.profiles.items) |profile| {
-            if (profile.keybind) |kb| alloc.free(kb);
-            if (profile.command) |cmd| alloc.free(cmd);
-            if (profile.cwd) |cwd| alloc.free(cwd);
-        }
-        for (self.commands_z.items) |cmd_z| {
-            if (cmd_z) |ptr| {
-                const slice = std.mem.sliceTo(ptr, 0);
-                alloc.free(slice);
-            }
-        }
-        for (self.cwd_z.items) |cz| {
-            if (cz) |ptr| {
-                const slice = std.mem.sliceTo(ptr, 0);
-                alloc.free(slice);
-            }
-        }
-        self.names.deinit(alloc);
-        self.profiles.deinit(alloc);
+        for (self.entries.items) |entry| entry.deinit(alloc);
+        self.entries.deinit(alloc);
         self.names_c.deinit(alloc);
         self.profiles_c.deinit(alloc);
-        self.commands_z.deinit(alloc);
-        self.cwd_z.deinit(alloc);
     }
 
     /// Used by Formatter.
@@ -9500,23 +9444,27 @@ pub const RepeatablePopup = struct {
         formatter: formatterpkg.EntryFormatter,
     ) !void {
         _ = formatter;
-        if (self.names.items.len > 0) {
+        if (self.entries.items.len > 0) {
             log.warn(
                 "popup config entries cannot be serialized yet; {d} entries dropped",
-                .{self.names.items.len},
+                .{self.entries.items.len},
             );
         }
     }
 
     /// Compare if two values are equal. Required by Config.
     pub fn equal(a: Self, b: Self) bool {
-        if (a.names.items.len != b.names.items.len) return false;
-        for (a.names.items, a.profiles.items, 0..) |name_a, prof_a, i| {
-            const name_b = b.names.items[i];
-            if (!std.mem.eql(u8, name_a, name_b)) return false;
+        if (a.entries.items.len != b.entries.items.len) return false;
+        for (a.entries.items, 0..) |entry_a, i| {
+            const entry_b = b.entries.items[i];
+            if (!std.mem.eql(u8, entry_a.named_profile.name, entry_b.named_profile.name)) return false;
             // Use deepEqual for content-based comparison of profile fields,
             // including optional string fields (keybind, command).
-            if (!deepEqual(popupmod.PopupProfile, prof_a, b.profiles.items[i])) return false;
+            if (!deepEqual(
+                popupmod.PopupProfile,
+                entry_a.named_profile.profile,
+                entry_b.named_profile.profile,
+            )) return false;
         }
         return true;
     }
@@ -11516,7 +11464,7 @@ test "popup: basic parsing via CLI" {
     try popups.parseCLI(alloc, "myterm:width:80%,height:50%");
     try popups.parseCLI(alloc, "other:width:400,height:300");
 
-    try testing.expectEqual(@as(usize, 2), popups.names.items.len);
+    try testing.expectEqual(@as(usize, 2), popups.entries.items.len);
 
     const p1 = popups.get("myterm");
     try testing.expect(p1 != null);
@@ -11548,7 +11496,7 @@ test "popup: duplicate name replacement" {
     try popups.parseCLI(alloc, "myterm:width:100%");
 
     // Should only have one profile named "myterm"
-    try testing.expectEqual(@as(usize, 1), popups.names.items.len);
+    try testing.expectEqual(@as(usize, 1), popups.entries.items.len);
 
     // Should be the second definition (100%)
     const profile = popups.get("myterm");
@@ -11567,11 +11515,11 @@ test "popup: parseCLI empty clears profiles" {
     var popups: RepeatablePopup = .{};
     try popups.parseCLI(alloc, "myterm:width:80%");
     try popups.parseCLI(alloc, "other:width:50%");
-    try testing.expectEqual(@as(usize, 2), popups.names.items.len);
+    try testing.expectEqual(@as(usize, 2), popups.entries.items.len);
 
     // Clear with empty string
     try popups.parseCLI(alloc, "");
-    try testing.expectEqual(@as(usize, 0), popups.names.items.len);
+    try testing.expectEqual(@as(usize, 0), popups.entries.items.len);
 }
 
 test "popup: invalid name rejected" {
@@ -11585,7 +11533,7 @@ test "popup: invalid name rejected" {
     // Names with spaces or special chars should be rejected
     try testing.expectError(error.InvalidValue, popups.parseCLI(alloc, "bad name:width:80%"));
     try testing.expectError(error.InvalidValue, popups.parseCLI(alloc, "bad@name:width:80%"));
-    try testing.expectEqual(@as(usize, 0), popups.names.items.len);
+    try testing.expectEqual(@as(usize, 0), popups.entries.items.len);
 }
 
 test "popup: opacity is clamped during CLI parsing" {
@@ -11609,4 +11557,43 @@ test "popup: opacity is clamped during CLI parsing" {
     if (high) |p| {
         try testing.expectEqual(@as(?f64, 1.0), p.opacity);
     }
+}
+
+test "popup: upsert rolls back on allocation failure" {
+    const testing = std.testing;
+    const profile = popupmod.PopupProfile{
+        .width = popupmod.Dimension.initPercent(80),
+        .height = popupmod.Dimension.initPercent(50),
+        .command = "echo hello",
+        .cwd = "~/tmp",
+        .keybind = "ctrl+grave_accent",
+    };
+
+    var fail_index: usize = 0;
+    var saw_success = false;
+    while (fail_index < 64) : (fail_index += 1) {
+        var fail_alloc_state = std.testing.FailingAllocator.init(testing.allocator, .{
+            .fail_index = fail_index,
+        });
+        const fail_alloc = fail_alloc_state.allocator();
+
+        var popups: RepeatablePopup = .{};
+        defer popups.deinit(fail_alloc);
+
+        const result = popups.upsert(fail_alloc, "demo", profile);
+
+        if (result) |_| {
+            saw_success = true;
+            break;
+        } else |err| switch (err) {
+            error.OutOfMemory => {
+                try testing.expectEqual(@as(usize, 0), popups.entries.items.len);
+                try testing.expectEqual(@as(usize, 0), popups.names_c.items.len);
+                try testing.expectEqual(@as(usize, 0), popups.profiles_c.items.len);
+            },
+            else => return err,
+        }
+    }
+
+    try testing.expect(saw_success);
 }


### PR DESCRIPTION
## Summary
- fix popup cwd inheritance
- repair popup config ownership and parsing cleanup
- address the popup issue set for #7, #8, #10, and #12

## Related Issues
- Closes #7
- Closes #8
- Closes #10
- Closes #12

## macOS Test Plan
- Not run; this fix set is in the GTK popup path.

## Linux Test Plan
- `zig test src/apprt/popup.zig`