### PR TITLE
[codex] Fix release automation issues (#67-#69)

### DIFF
--- a/.github/scripts/test_update_homebrew_cask.py
+++ b/.github/scripts/test_update_homebrew_cask.py
@@ -1,0 +1,69 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("update_homebrew_cask.py")
+SPEC = importlib.util.spec_from_file_location("update_homebrew_cask", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class UpdateHomebrewCaskTests(unittest.TestCase):
+    def test_updates_stable_cask_version_sha_and_asset_id(self) -> None:
+        original = """cask "trident" do
+  version "v1.3.4"
+  sha256 "oldsha"
+
+  url "https://api.github.com/repos/subdepthtech/Trident/releases/assets/389041788",
+      header: [
+        "Accept: application/octet-stream",
+        "Authorization: token #{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", "")}",
+      ]
+end
+"""
+
+        updated = MODULE.update_cask_text(
+            original,
+            version="v1.3.5",
+            asset_id="400000001",
+            sha256="newsha",
+        )
+
+        self.assertIn('version "v1.3.5"', updated)
+        self.assertIn('sha256 "newsha"', updated)
+        self.assertIn("releases/assets/400000001", updated)
+        self.assertNotIn("releases/assets/389041788", updated)
+
+    def test_updates_dev_cask_to_no_check_sha(self) -> None:
+        original = """cask "trident-dev" do
+  version "87ef6ce80"
+  sha256 "oldsha"
+
+  url "https://api.github.com/repos/subdepthtech/Trident/releases/assets/389042162",
+      header: [
+        "Accept: application/octet-stream",
+        "Authorization: token #{ENV.fetch("HOMEBREW_GITHUB_API_TOKEN", "")}",
+      ]
+end
+"""
+
+        updated = MODULE.update_cask_text(
+            original,
+            version="149151339",
+            asset_id="400000002",
+            sha256=":no_check",
+        )
+
+        self.assertIn('version "149151339"', updated)
+        self.assertIn("sha256 :no_check", updated)
+        self.assertNotIn('sha256 "oldsha"', updated)
+        self.assertIn("releases/assets/400000002", updated)
+
+    def test_raises_when_expected_patterns_are_missing(self) -> None:
+        with self.assertRaisesRegex(ValueError, "version"):
+            MODULE.update_cask_text("cask \"trident\" do\nend\n", "v1.0.0", "123", "abc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_homebrew_cask.py
+++ b/.github/scripts/update_homebrew_cask.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+VERSION_RE = re.compile(r'version "[^"]+"')
+SHA_RE = re.compile(r"sha256 .+")
+ASSET_RE = re.compile(r"releases/assets/\d+")
+
+
+def replace_once(pattern: re.Pattern[str], text: str, replacement: str, label: str) -> str:
+    updated, count = pattern.subn(replacement, text, count=1)
+    if count != 1:
+        raise ValueError(f"Could not update {label} in cask file")
+    return updated
+
+
+def update_cask_text(text: str, version: str, asset_id: str, sha256: str) -> str:
+    updated = replace_once(VERSION_RE, text, f'version "{version}"', "version")
+    updated = replace_once(ASSET_RE, updated, f"releases/assets/{asset_id}", "asset ID")
+
+    sha_line = "sha256 :no_check" if sha256 == ":no_check" else f'sha256 "{sha256}"'
+    updated = replace_once(SHA_RE, updated, sha_line, "sha256")
+    return updated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update a Homebrew cask file for a new Trident release asset.")
+    parser.add_argument("--cask-file", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--asset-id", required=True)
+    parser.add_argument("--sha256", required=True)
+    args = parser.parse_args()
+
+    cask_path = pathlib.Path(args.cask_file)
+    original = cask_path.read_text()
+    updated = update_cask_text(
+        original,
+        version=args.version,
+        asset_id=args.asset_id,
+        sha256=args.sha256,
+    )
+
+    if updated != original:
+        cask_path.write_text(updated)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1)

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -149,6 +149,9 @@ jobs:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
+      - name: Xcode Select
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
       - name: Xcode Version
         run: xcodebuild -version
 
@@ -363,6 +366,8 @@ jobs:
     env:
       GHOSTTY_VERSION: ${{ needs.setup.outputs.version }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Download macOS Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -415,3 +420,57 @@ jobs:
           r2-bucket: ghostty-release
           source-dir: blob
           destination-dir: ./
+
+      - name: Verify Homebrew tap token
+        env:
+          SUBDEPTH_RELEASE_TOKEN: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
+        run: |
+          if [ -z "$SUBDEPTH_RELEASE_TOKEN" ]; then
+            echo "::error::SUBDEPTH_RELEASE_TOKEN is required to update subdepthtech/homebrew-trident."
+            exit 1
+          fi
+
+      - name: Resolve Homebrew cask metadata
+        id: homebrew
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          asset_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${GHOSTTY_VERSION}" --jq '.assets[] | select(.name=="Trident.dmg") | .id')
+          sha256=$(shasum -a 256 Trident.dmg | awk '{print $1}')
+          test -n "$asset_id"
+          test -n "$sha256"
+          echo "asset_id=$asset_id" >> "$GITHUB_OUTPUT"
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: subdepthtech/homebrew-trident
+          ref: main
+          path: homebrew-trident
+          token: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
+          persist-credentials: false
+
+      - name: Update stable Homebrew cask
+        run: |
+          python3 .github/scripts/update_homebrew_cask.py \
+            --cask-file homebrew-trident/Casks/trident.rb \
+            --version "v${GHOSTTY_VERSION}" \
+            --asset-id "${{ steps.homebrew.outputs.asset_id }}" \
+            --sha256 "${{ steps.homebrew.outputs.sha256 }}"
+
+      - name: Commit and push stable Homebrew cask
+        env:
+          SUBDEPTH_RELEASE_TOKEN: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
+        run: |
+          cd homebrew-trident
+          if git diff --quiet --exit-code -- Casks/trident.rb; then
+            echo "Stable cask already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/trident.rb
+          git commit -m "Update trident cask to v${GHOSTTY_VERSION}"
+          git push "https://x-access-token:${SUBDEPTH_RELEASE_TOKEN}@github.com/subdepthtech/homebrew-trident.git" HEAD:main

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -436,9 +436,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           asset_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${GHOSTTY_VERSION}" --jq '.assets[] | select(.name=="Trident.dmg") | .id')
-          sha256=$(shasum -a 256 Trident.dmg | awk '{print $1}')
-          test -n "$asset_id"
-          test -n "$sha256"
+          if [ -z "$asset_id" ]; then
+            echo "::error::Could not find Trident.dmg asset ID on release v${GHOSTTY_VERSION}."
+            exit 1
+          fi
+
+          dmg_path="blob/${GHOSTTY_VERSION}/Trident.dmg"
+          if [ ! -f "$dmg_path" ]; then
+            echo "::error::Expected DMG at $dmg_path before computing the stable cask checksum."
+            exit 1
+          fi
+
+          sha256=$(shasum -a 256 "$dmg_path" | awk '{print $1}')
+          if [ -z "$sha256" ]; then
+            echo "::error::Could not compute SHA-256 for $dmg_path."
+            exit 1
+          fi
           echo "asset_id=$asset_id" >> "$GITHUB_OUTPUT"
           echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -455,6 +455,7 @@ jobs:
           destination-dir: ./
 
       - name: Verify Homebrew tap token
+        if: github.ref_name == 'main'
         env:
           SUBDEPTH_RELEASE_TOKEN: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
         run: |
@@ -465,14 +466,19 @@ jobs:
 
       - name: Resolve Homebrew cask metadata
         id: homebrew
+        if: github.ref_name == 'main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           asset_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/tip" --jq '.assets[] | select(.name=="Trident-Dev.dmg") | .id')
-          test -n "$asset_id"
+          if [ -z "$asset_id" ]; then
+            echo "::error::Could not find Trident-Dev.dmg asset ID on the tip release."
+            exit 1
+          fi
           echo "asset_id=$asset_id" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Homebrew tap
+        if: github.ref_name == 'main'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: subdepthtech/homebrew-trident
@@ -482,6 +488,7 @@ jobs:
           persist-credentials: false
 
       - name: Update dev Homebrew cask
+        if: github.ref_name == 'main'
         run: |
           python3 .github/scripts/update_homebrew_cask.py \
             --cask-file homebrew-trident/Casks/trident-dev.rb \
@@ -490,6 +497,7 @@ jobs:
             --sha256 ":no_check"
 
       - name: Commit and push dev Homebrew cask
+        if: github.ref_name == 'main'
         env:
           SUBDEPTH_RELEASE_TOKEN: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
         run: |

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -245,6 +245,9 @@ jobs:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
+      - name: Xcode Select
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
       - name: Xcode Version
         run: xcodebuild -version
 
@@ -451,6 +454,57 @@ jobs:
           source-dir: blob
           destination-dir: ./
 
+      - name: Verify Homebrew tap token
+        env:
+          SUBDEPTH_RELEASE_TOKEN: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
+        run: |
+          if [ -z "$SUBDEPTH_RELEASE_TOKEN" ]; then
+            echo "::error::SUBDEPTH_RELEASE_TOKEN is required to update subdepthtech/homebrew-trident."
+            exit 1
+          fi
+
+      - name: Resolve Homebrew cask metadata
+        id: homebrew
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          asset_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/tip" --jq '.assets[] | select(.name=="Trident-Dev.dmg") | .id')
+          test -n "$asset_id"
+          echo "asset_id=$asset_id" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: subdepthtech/homebrew-trident
+          ref: main
+          path: homebrew-trident
+          token: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
+          persist-credentials: false
+
+      - name: Update dev Homebrew cask
+        run: |
+          python3 .github/scripts/update_homebrew_cask.py \
+            --cask-file homebrew-trident/Casks/trident-dev.rb \
+            --version "${GHOSTTY_COMMIT}" \
+            --asset-id "${{ steps.homebrew.outputs.asset_id }}" \
+            --sha256 ":no_check"
+
+      - name: Commit and push dev Homebrew cask
+        env:
+          SUBDEPTH_RELEASE_TOKEN: ${{ secrets.SUBDEPTH_RELEASE_TOKEN }}
+        run: |
+          cd homebrew-trident
+          if git diff --quiet --exit-code -- Casks/trident-dev.rb; then
+            echo "Dev cask already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/trident-dev.rb
+          git commit -m "Update trident-dev cask to ${GHOSTTY_COMMIT}"
+          git push "https://x-access-token:${SUBDEPTH_RELEASE_TOKEN}@github.com/subdepthtech/homebrew-trident.git" HEAD:main
+
       - name: Show and Save Release URLs
         if: env.HAS_R2_UPLOAD == 'true'
         run: |
@@ -500,6 +554,9 @@ jobs:
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Xcode Select
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -685,6 +742,9 @@ jobs:
         with:
           name: ghostty
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Xcode Select
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Xcode Version
         run: xcodebuild -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
       - build-nix
       - build-macos
       - build-macos-freetype
+      - test-release-scripts
       - build-snap
       - build-windows
       - test
@@ -166,6 +167,15 @@ jobs:
 
       - name: Build Benchmarks
         run: nix develop -c zig build -Demit-bench
+
+  test-release-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Test release helper scripts
+        run: python3 .github/scripts/test_update_homebrew_cask.py
 
   build-examples:
     strategy:


### PR DESCRIPTION
## Summary
- automate Homebrew cask update handling in the release workflows
- fix the release follow-ups behind #67, #68, and #69

## Related Issues
- Closes #67
- Closes #68
- Closes #69

## macOS Test Plan
- Not run; workflow and script changes only.

## Linux Test Plan
- Not run; workflow and script changes only.

## Other Verification
- `python3 .github/scripts/test_update_homebrew_cask.py`