### PR TITLE
[codex] Fix autofill issues (#1-#6)

### DIFF
--- a/macos/Sources/Features/Browser/Autofill/AutofillOverlayView.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillOverlayView.swift
@@ -35,6 +35,10 @@ struct AutofillOverlayView: View {
 
             Spacer()
         }
+        .task(id: controller.showSave) {
+            guard controller.showSave else { return }
+            await store.ensureVaultNamesLoaded()
+        }
     }
 }
 
@@ -297,6 +301,11 @@ private struct SavePromptView: View {
             editableTitle = controller.pendingSaveTitle
             editableUsername = controller.pendingSaveUsername
             selectedVault = availableVaults.first ?? ""
+        }
+        .onChange(of: availableVaults) { newVaults in
+            if selectedVault.isEmpty {
+                selectedVault = newVaults.first ?? ""
+            }
         }
     }
 }

--- a/macos/Sources/Features/Browser/Autofill/AutofillOverlayView.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillOverlayView.swift
@@ -6,12 +6,16 @@ import SwiftUI
 /// Renders whichever autofill UI state is active for the current tab.
 struct AutofillOverlayView: View {
     @ObservedObject var controller: BrowserAutofillController
-    var availableVaults: [String]
+    @ObservedObject var store: AutofillStore
 
     var body: some View {
         VStack(spacing: 0) {
             if controller.sessionExpired {
                 SessionExpiredBanner(controller: controller)
+            }
+
+            if let message = controller.fillErrorMessage {
+                FillErrorBanner(message: message, controller: controller)
             }
 
             if controller.showPrompt, !controller.matchingCredentials.isEmpty {
@@ -25,12 +29,41 @@ struct AutofillOverlayView: View {
             if controller.showSave {
                 SavePromptView(
                     controller: controller,
-                    availableVaults: availableVaults
+                    availableVaults: store.availableVaultNames
                 )
             }
 
             Spacer()
         }
+    }
+}
+
+// MARK: - FillErrorBanner
+
+private struct FillErrorBanner: View {
+    let message: String
+    @ObservedObject var controller: BrowserAutofillController
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.orange)
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundColor(.primary)
+            Spacer()
+            Button(action: { controller.dismissFillError() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 0)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
     }
 }
 
@@ -225,6 +258,12 @@ private struct SavePromptView: View {
                     .labelsHidden()
                     .frame(maxWidth: 160)
                 }
+            }
+
+            if availableVaults.isEmpty {
+                Text("No Proton Pass vaults are available yet.")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
             }
 
             HStack {

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+struct AutofillProcessResult {
+    let output: String
+    let stderr: String
+    let exitCode: Int32
+}
+
 // MARK: - PassCredentialMeta
 
 /// Metadata extracted from a single Proton Pass login item.
@@ -37,6 +43,7 @@ struct PassCredentialMeta: Identifiable {
 /// Never holds passwords or TOTP secrets.
 private struct VaultIndex {
     var items: [PassCredentialMeta] = []
+    var shareIdToVaultName: [String: String] = [:]
     var loadedAt: Date?
 
     var isStale: Bool {
@@ -55,32 +62,53 @@ private struct VaultIndex {
 /// index of what's in the vault and only reaches out to the real store
 /// when it needs to resolve a specific secret.
 final class AutofillStore: ObservableObject {
+    typealias ProcessRunner = (String, [String], String?) async -> AutofillProcessResult
 
     // MARK: - Published State
 
     /// True when pass-cli is not installed or session has expired.
-    @Published private(set) var isUnavailable: Bool = false
+    @MainActor @Published private(set) var isUnavailable: Bool = false
     /// Human-readable reason autofill is unavailable (for banner display).
-    @Published private(set) var unavailableReason: String = ""
+    @MainActor @Published private(set) var unavailableReason: String = ""
+    /// Vault names available for save operations.
+    @MainActor @Published private(set) var availableVaultNames: [String]
 
     // MARK: - Private State
 
-    private var index = VaultIndex()
-    private var passCLIPath: String?
+    @MainActor private var index = VaultIndex()
+    @MainActor private var passCLIPath: String?
     /// Optional vault name to restrict lookups. Nil = all vaults.
     private let vaultName: String?
+    private let processRunner: ProcessRunner
 
     // MARK: - Init
 
     /// Discover pass-cli and record the optional vault restriction.
     /// - Parameter vaultName: Vault to restrict to, or nil for all vaults.
-    init(vaultName: String?) {
+    init(
+        vaultName: String?,
+        passCLIPath: String? = nil,
+        autoDiscoverCLI: Bool = true,
+        processRunner: @escaping ProcessRunner = AutofillStore.defaultRunProcess
+    ) {
         self.vaultName = vaultName
-        Task { await discoverCLI() }
+        self.passCLIPath = passCLIPath
+        self.availableVaultNames = vaultName.map { [$0] } ?? []
+        self.processRunner = processRunner
+
+        if autoDiscoverCLI {
+            Task { @MainActor in
+                await discoverCLI()
+            }
+        } else if passCLIPath != nil {
+            isUnavailable = false
+            unavailableReason = ""
+        }
     }
 
     // MARK: - CLI Discovery
 
+    @MainActor
     private func discoverCLI() async {
         // Finder-launched apps get a minimal PATH that excludes ~/.local/bin,
         // /opt/homebrew/bin, etc. Check well-known locations directly instead
@@ -118,30 +146,25 @@ final class AutofillStore: ObservableObject {
         }
 
         print("[AutofillStore] pass-cli not found — autofill disabled")
-        await MainActor.run {
-            isUnavailable = true
-            unavailableReason = "pass-cli not found — install it or add it to PATH"
-        }
+        isUnavailable = true
+        unavailableReason = "pass-cli not found — install it or add it to PATH"
     }
 
     // MARK: - Session Check
 
     /// Runs `pass-cli test` to verify the session is active.
     /// Sets isUnavailable if the session is expired.
+    @MainActor
     func checkSession() async {
         guard let cli = passCLIPath else { return }
         let result = await runProcess(executable: cli, arguments: ["test"], input: nil)
         if result.exitCode != 0 {
             print("[AutofillStore] pass-cli session expired")
-            await MainActor.run {
-                isUnavailable = true
-                unavailableReason = "Proton Pass session expired — run `pass-cli login` in a terminal"
-            }
+            isUnavailable = true
+            unavailableReason = "Proton Pass session expired — run `pass-cli login` in a terminal"
         } else {
-            await MainActor.run {
-                isUnavailable = false
-                unavailableReason = ""
-            }
+            isUnavailable = false
+            unavailableReason = ""
         }
     }
 
@@ -150,6 +173,7 @@ final class AutofillStore: ObservableObject {
     /// Find all cached credentials that match the given URL.
     /// Performs exact-host matching with www-prefix stripping.
     /// Returns empty array if autofill is unavailable or URL is not HTTPS.
+    @MainActor
     func findMatches(for pageURL: URL) async -> [PassCredentialMeta] {
         guard !isUnavailable else { return [] }
 
@@ -164,19 +188,19 @@ final class AutofillStore: ObservableObject {
             await refreshIndex()
         }
 
-        guard let pageHost = normalizeHost(pageURL.host) else { return [] }
+        guard let pageHost = Self.normalizeHost(pageURL.host) else { return [] }
 
         return index.items.filter { item in
             item.urls.contains { urlStr in
                 // Try the URL as-is first
                 if let url = URL(string: urlStr),
-                   let itemHost = normalizeHost(url.host) {
+                   let itemHost = Self.normalizeHost(url.host) {
                     return itemHost == pageHost
                 }
                 // If host is nil and URL has no scheme, try prepending https://
                 if !urlStr.contains("://"),
                    let url = URL(string: "https://\(urlStr)"),
-                   let itemHost = normalizeHost(url.host) {
+                   let itemHost = Self.normalizeHost(url.host) {
                     return itemHost == pageHost
                 }
                 return false
@@ -187,6 +211,7 @@ final class AutofillStore: ObservableObject {
     // MARK: - Index Refresh
 
     /// Re-loads the vault index from pass-cli. Called when index is stale.
+    @MainActor
     private func refreshIndex() async {
         guard let cli = passCLIPath else { return }
 
@@ -216,9 +241,11 @@ final class AutofillStore: ObservableObject {
             }
             vaultNames = vaults.compactMap { $0["name"] as? String }
         }
+        availableVaultNames = vaultNames
 
         // Load items from each vault and merge
         var allItems: [PassCredentialMeta] = []
+        var shareIdToVaultName: [String: String] = [:]
         for name in vaultNames {
             let result = await runProcess(
                 executable: cli,
@@ -231,9 +258,13 @@ final class AutofillStore: ObservableObject {
             }
             let parsed = parseItemList(result.output)
             allItems.append(contentsOf: parsed)
+            for item in parsed {
+                shareIdToVaultName[item.shareId] = name
+            }
         }
 
         index.items = allItems
+        index.shareIdToVaultName = shareIdToVaultName
         index.loadedAt = Date()
         print("[AutofillStore] Index loaded: \(allItems.count) login item(s)")
     }
@@ -297,6 +328,7 @@ final class AutofillStore: ObservableObject {
     /// Fetch the full credential (username + password) for a given item.
     /// Secrets are fetched on demand and should be used immediately, not stored.
     /// Returns nil if the fetch fails.
+    @MainActor
     func fetchCredential(shareId: String, itemId: String) async -> (username: String, email: String, password: String)? {
         guard let cli = passCLIPath else { return nil }
 
@@ -329,6 +361,7 @@ final class AutofillStore: ObservableObject {
 
     /// Fetch a TOTP code for an item with hasTOTP = true.
     /// Returns nil if the item has no TOTP or the fetch fails.
+    @MainActor
     func fetchTOTP(shareId: String, itemId: String) async -> String? {
         guard let cli = passCLIPath else { return nil }
 
@@ -360,6 +393,7 @@ final class AutofillStore: ObservableObject {
 
     /// Save a new login item to the vault via `pass-cli item create login --from-template -`.
     /// The template JSON is piped via stdin — password never appears in argv.
+    @MainActor
     func saveCredential(
         title: String,
         username: String,
@@ -405,25 +439,36 @@ final class AutofillStore: ObservableObject {
 
     /// Returns the vault name for a given shareId by searching the index.
     /// Falls back to the configured vaultName, then nil.
+    @MainActor
     private func vaultNameForShareId(_ shareId: String) -> String? {
         if let name = vaultName { return name }
-        return nil
+        return index.shareIdToVaultName[shareId]
     }
 
     // MARK: - Subprocess Helper
-
-    private struct ProcessResult {
-        let output: String
-        let stderr: String
-        let exitCode: Int32
-    }
 
     /// Run an external process off the main thread, optionally piping `input` to stdin.
     private func runProcess(
         executable: String,
         arguments: [String],
         input: String?
-    ) async -> ProcessResult {
+    ) async -> AutofillProcessResult {
+        await processRunner(executable, arguments, input)
+    }
+
+    static func runProcessForTesting(
+        executable: String,
+        arguments: [String],
+        input: String?
+    ) async -> AutofillProcessResult {
+        await defaultRunProcess(executable, arguments, input)
+    }
+
+    private static func defaultRunProcess(
+        executable: String,
+        arguments: [String],
+        input: String?
+    ) async -> AutofillProcessResult {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
@@ -446,18 +491,34 @@ final class AutofillStore: ObservableObject {
 
                 do {
                     try process.run()
-                    process.waitUntilExit()
                 } catch {
-                    continuation.resume(returning: ProcessResult(output: "", stderr: error.localizedDescription, exitCode: -1))
+                    continuation.resume(returning: AutofillProcessResult(output: "", stderr: error.localizedDescription, exitCode: -1))
                     return
                 }
 
-                let outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                let group = DispatchGroup()
+                var outData = Data()
+                var errData = Data()
+
+                group.enter()
+                DispatchQueue.global(qos: .userInitiated).async {
+                    outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                    group.leave()
+                }
+
+                group.enter()
+                DispatchQueue.global(qos: .userInitiated).async {
+                    errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                    group.leave()
+                }
+
+                process.waitUntilExit()
+                group.wait()
+
                 let output = String(data: outData, encoding: .utf8) ?? ""
                 let stderr = String(data: errData, encoding: .utf8) ?? ""
 
-                continuation.resume(returning: ProcessResult(
+                continuation.resume(returning: AutofillProcessResult(
                     output: output,
                     stderr: stderr,
                     exitCode: process.terminationStatus
@@ -469,7 +530,7 @@ final class AutofillStore: ObservableObject {
     // MARK: - Host Normalization
 
     /// Strip www. prefix and lowercase the host.
-    private func normalizeHost(_ host: String?) -> String? {
+    static func normalizeHost(_ host: String?) -> String? {
         guard var h = host, !h.isEmpty else { return nil }
         if h.lowercased().hasPrefix("www.") {
             h = String(h.dropFirst(4))

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -208,6 +208,19 @@ final class AutofillStore: ObservableObject {
         }
     }
 
+    /// Load vault names for save flows that may happen before any match refresh.
+    @MainActor
+    func ensureVaultNamesLoaded() async {
+        guard availableVaultNames.isEmpty else { return }
+        guard vaultName == nil else { return }
+        guard let _ = passCLIPath else { return }
+
+        let vaultNames = await loadVaultNames()
+        if !vaultNames.isEmpty {
+            availableVaultNames = vaultNames
+        }
+    }
+
     // MARK: - Index Refresh
 
     /// Re-loads the vault index from pass-cli. Called when index is stale.
@@ -218,28 +231,12 @@ final class AutofillStore: ObservableObject {
         print("[AutofillStore] Refreshing vault index...")
 
         // Determine which vault(s) to load
-        var vaultNames: [String] = []
+        let vaultNames: [String]
         if let name = vaultName {
             vaultNames = [name]
         } else {
-            // Enumerate all vaults
-            let result = await runProcess(
-                executable: cli,
-                arguments: ["vault", "list", "--output", "json"],
-                input: nil
-            )
-            if result.exitCode != 0 {
-                print("[AutofillStore] vault list failed: \(result.stderr)")
-                await checkSession()
-                return
-            }
-            guard let data = result.output.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let vaults = json["vaults"] as? [[String: Any]] else {
-                print("[AutofillStore] Failed to parse vault list JSON")
-                return
-            }
-            vaultNames = vaults.compactMap { $0["name"] as? String }
+            vaultNames = await loadVaultNames()
+            if vaultNames.isEmpty { return }
         }
         availableVaultNames = vaultNames
 
@@ -443,6 +440,30 @@ final class AutofillStore: ObservableObject {
     private func vaultNameForShareId(_ shareId: String) -> String? {
         if let name = vaultName { return name }
         return index.shareIdToVaultName[shareId]
+    }
+
+    @MainActor
+    private func loadVaultNames() async -> [String] {
+        guard let cli = passCLIPath else { return [] }
+
+        let result = await runProcess(
+            executable: cli,
+            arguments: ["vault", "list", "--output", "json"],
+            input: nil
+        )
+        if result.exitCode != 0 {
+            print("[AutofillStore] vault list failed: \(result.stderr)")
+            await checkSession()
+            return []
+        }
+        guard let data = result.output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let vaults = json["vaults"] as? [[String: Any]] else {
+            print("[AutofillStore] Failed to parse vault list JSON")
+            return []
+        }
+
+        return vaults.compactMap { $0["name"] as? String }
     }
 
     // MARK: - Subprocess Helper

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -93,16 +93,13 @@ final class AutofillStore: ObservableObject {
     ) {
         self.vaultName = vaultName
         self.passCLIPath = passCLIPath
-        self.availableVaultNames = vaultName.map { [$0] } ?? []
+        self._availableVaultNames = Published(initialValue: vaultName.map { [$0] } ?? [])
         self.processRunner = processRunner
 
         if autoDiscoverCLI {
             Task { @MainActor in
                 await discoverCLI()
             }
-        } else if passCLIPath != nil {
-            isUnavailable = false
-            unavailableReason = ""
         }
     }
 
@@ -496,7 +493,7 @@ final class AutofillStore: ObservableObject {
         arguments: [String],
         input: String?
     ) async -> AutofillProcessResult {
-        await defaultRunProcess(executable, arguments, input)
+        await defaultRunProcess(executable: executable, arguments: arguments, input: input)
     }
 
     private static func defaultRunProcess(

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -132,6 +132,7 @@ final class AutofillStore: ObservableObject {
             passCLIPath = whichPath
             print("[AutofillStore] pass-cli discovered via login shell at: \(whichPath)")
             await checkSession()
+            await loadVaultNamesAfterDiscoveryIfNeeded()
             return
         }
 
@@ -141,6 +142,7 @@ final class AutofillStore: ObservableObject {
                 passCLIPath = path
                 print("[AutofillStore] pass-cli discovered at: \(path)")
                 await checkSession()
+                await loadVaultNamesAfterDiscoveryIfNeeded()
                 return
             }
         }
@@ -464,6 +466,18 @@ final class AutofillStore: ObservableObject {
         }
 
         return vaults.compactMap { $0["name"] as? String }
+    }
+
+    @MainActor
+    private func loadVaultNamesAfterDiscoveryIfNeeded() async {
+        guard vaultName == nil else { return }
+        guard availableVaultNames.isEmpty else { return }
+        guard !isUnavailable else { return }
+
+        let vaultNames = await loadVaultNames()
+        if !vaultNames.isEmpty {
+            availableVaultNames = vaultNames
+        }
     }
 
     // MARK: - Subprocess Helper

--- a/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
+++ b/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
@@ -44,6 +44,10 @@ final class BrowserAutofillController: ObservableObject {
     /// Active TOTP clear timer.
     private var totpClearTimer: DispatchWorkItem?
 
+    var hasInteractiveOverlayContent: Bool {
+        showPrompt || showSave || sessionExpired || fillErrorMessage != nil
+    }
+
     // MARK: - Init
 
     init(store: AutofillStore) {

--- a/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
+++ b/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
@@ -25,6 +25,8 @@ final class BrowserAutofillController: ObservableObject {
     @Published var totpCode: String?
     /// True when AutofillStore reports session expired.
     @Published var sessionExpired: Bool = false
+    /// User-visible fill error shown in the overlay.
+    @Published var fillErrorMessage: String?
 
     // MARK: - Private State
 
@@ -51,6 +53,13 @@ final class BrowserAutofillController: ObservableObject {
     /// Called by BrowserPaneModel once the WKWebView is created.
     func attach(to webView: WKWebView) {
         self.webView = webView
+    }
+
+    func handleNavigation(to url: URL?) {
+        autofillDidFill = false
+        detectedUsernameSelector = nil
+        detectedPasswordSelector = nil
+        fillErrorMessage = nil
     }
 
     // MARK: - Message Dispatch
@@ -95,11 +104,11 @@ final class BrowserAutofillController: ObservableObject {
         guard let webView,
               let pageURL = webView.url else { return false }
 
-        let msgHost = message.frameInfo.securityOrigin.host
-        let pageHost = pageURL.host ?? ""
+        let msgHost = AutofillStore.normalizeHost(message.frameInfo.securityOrigin.host)
+        let pageHost = AutofillStore.normalizeHost(pageURL.host)
 
-        guard !msgHost.isEmpty, !pageHost.isEmpty else { return false }
-        return msgHost.lowercased() == pageHost.lowercased()
+        guard let msgHost, let pageHost else { return false }
+        return msgHost == pageHost
     }
 
     // MARK: - Form Detected Handler
@@ -120,9 +129,9 @@ final class BrowserAutofillController: ObservableObject {
 
         Task {
             // Re-check session if previously unavailable
-            if store.isUnavailable {
+            if await store.isUnavailable {
                 await store.checkSession()
-                let stillUnavailable = store.isUnavailable
+                let stillUnavailable = await store.isUnavailable
                 await MainActor.run {
                     sessionExpired = stillUnavailable
                 }
@@ -141,19 +150,24 @@ final class BrowserAutofillController: ObservableObject {
     // MARK: - Submit Detected Handler
 
     private func handleSubmitDetected(body: [String: Any]) {
+        let domain = webView?.url?.host ?? "Unknown site"
+        consumeSubmitDetected(
+            isNewPassword: body["isNewPassword"] as? Bool ?? false,
+            username: body["username"] as? String ?? "",
+            password: body["password"] as? String ?? "",
+            domain: domain
+        )
+    }
+
+    func consumeSubmitDetected(isNewPassword: Bool, username: String, password: String, domain: String) {
         // If we just filled this form ourselves, suppress the save prompt
         guard !autofillDidFill else {
             autofillDidFill = false
             return
         }
 
-        guard let isNewPassword = body["isNewPassword"] as? Bool, isNewPassword else { return }
-
-        let username = body["username"] as? String ?? ""
-        let password = body["password"] as? String ?? ""
+        guard isNewPassword else { return }
         guard !password.isEmpty else { return }
-
-        let domain = webView?.url?.host ?? "Unknown site"
 
         pendingSaveUsername = username
         pendingSavePassword = password
@@ -173,44 +187,74 @@ final class BrowserAutofillController: ObservableObject {
                 shareId: credential.shareId,
                 itemId: credential.itemId
             ) else {
+                await MainActor.run {
+                    fillErrorMessage = "Could not load this Proton Pass login. Check your session and try again."
+                }
                 print("[AutofillController] fetchCredential returned nil")
                 return
             }
 
             let usernameValue = secret.email.isEmpty ? secret.username : secret.email
 
-            // Fill username via callAsyncJavaScript with arguments (no string interpolation)
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                DispatchQueue.main.async {
-                    webView.callAsyncJavaScript(
-                        "return window.__tridentAutofillHelper.fill(selector, value)",
-                        arguments: [
-                            "selector": self.detectedUsernameSelector ?? "input[autocomplete=\"username\"], input[type=\"email\"], input[type=\"text\"]",
-                            "value": usernameValue
-                        ],
-                        in: nil,
-                        in: .defaultClient
-                    ) { _ in }
+            async let usernameFill = fillField(
+                in: webView,
+                selector: detectedUsernameSelector ?? "input[autocomplete=\"username\"], input[type=\"email\"], input[type=\"text\"]",
+                value: usernameValue
+            )
+            async let passwordFill = fillField(
+                in: webView,
+                selector: detectedPasswordSelector ?? "input[type=\"password\"]",
+                value: secret.password
+            )
 
-                    webView.callAsyncJavaScript(
-                        "return window.__tridentAutofillHelper.fill(selector, value)",
-                        arguments: [
-                            "selector": self.detectedPasswordSelector ?? "input[type=\"password\"]",
-                            "value": secret.password
-                        ],
-                        in: nil,
-                        in: .defaultClient
-                    ) { _ in
-                        continuation.resume()
-                    }
-                }
+            let usernameFilled = await usernameFill
+            let passwordFilled = await passwordFill
+
+            await MainActor.run {
+                autofillDidFill = usernameFilled || passwordFilled
+                fillErrorMessage = fillErrorMessageFor(usernameFilled: usernameFilled, passwordFilled: passwordFilled)
             }
-
-            await MainActor.run { autofillDidFill = true }
 
             if credential.hasTOTP {
                 await handleTOTP(shareId: credential.shareId, itemId: credential.itemId)
             }
+        }
+    }
+
+    private func fillField(in webView: WKWebView, selector: String, value: String) async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.main.async {
+                webView.callAsyncJavaScript(
+                    "return window.__tridentAutofillHelper.fill(selector, value)",
+                    arguments: [
+                        "selector": selector,
+                        "value": value
+                    ],
+                    in: nil,
+                    in: .defaultClient
+                ) { result in
+                    switch result {
+                    case .success(let value):
+                        continuation.resume(returning: value as? Bool ?? false)
+                    case .failure(let error):
+                        print("[AutofillController] JS fill failed for selector '\(selector)': \(error)")
+                        continuation.resume(returning: false)
+                    }
+                }
+            }
+        }
+    }
+
+    private func fillErrorMessageFor(usernameFilled: Bool, passwordFilled: Bool) -> String? {
+        switch (usernameFilled, passwordFilled) {
+        case (true, true):
+            return nil
+        case (false, false):
+            return "Could not find the login fields on this page."
+        case (false, true):
+            return "Filled the password, but the username field could not be found."
+        case (true, false):
+            return "Filled the username, but the password field could not be found."
         }
     }
 
@@ -226,13 +270,23 @@ final class BrowserAutofillController: ObservableObject {
             totpCode = code
             totpClearTimer?.cancel()
 
+            let expectedCode = code
             let item = DispatchWorkItem { [weak self] in
-                NSPasteboard.general.clearContents()
+                if Self.shouldClearTOTPPasteboard(
+                    currentString: NSPasteboard.general.string(forType: .string),
+                    expectedTOTP: expectedCode
+                ) {
+                    NSPasteboard.general.clearContents()
+                }
                 self?.totpCode = nil
             }
             totpClearTimer = item
             DispatchQueue.main.asyncAfter(deadline: .now() + 30, execute: item)
         }
+    }
+
+    static func shouldClearTOTPPasteboard(currentString: String?, expectedTOTP: String) -> Bool {
+        currentString == expectedTOTP
     }
 
     // MARK: - Save Credential
@@ -266,5 +320,9 @@ final class BrowserAutofillController: ObservableObject {
 
     func dismissSave() {
         showSave = false
+    }
+
+    func dismissFillError() {
+        fillErrorMessage = nil
     }
 }

--- a/macos/Sources/Features/Browser/BrowserPaneModel.swift
+++ b/macos/Sources/Features/Browser/BrowserPaneModel.swift
@@ -326,6 +326,7 @@ class BrowserPaneModel: NSObject, ObservableObject {
 
         observations.append(webView.observe(\.url) { [weak self] wv, _ in
             DispatchQueue.main.async {
+                self?.autofillController?.handleNavigation(to: wv.url)
                 self?.currentURL = wv.url
                 if let url = wv.url?.absoluteString, self?.urlString != url {
                     self?.urlString = url

--- a/macos/Sources/Features/Browser/BrowserPaneView.swift
+++ b/macos/Sources/Features/Browser/BrowserPaneView.swift
@@ -84,10 +84,11 @@ struct BrowserPaneView: View {
                     BrowserWebView(model: model, onBrowserFocused: onBrowserFocused)
                         .id(model.id)
 
-                    if let controller = model.autofillController {
+                    if let controller = model.autofillController,
+                       let store = tabManager.autofillStore {
                         AutofillOverlayView(
                             controller: controller,
-                            availableVaults: ["Personal"]
+                            store: store
                         )
                         .allowsHitTesting(
                             controller.showPrompt ||

--- a/macos/Sources/Features/Browser/BrowserPaneView.swift
+++ b/macos/Sources/Features/Browser/BrowserPaneView.swift
@@ -90,11 +90,7 @@ struct BrowserPaneView: View {
                             controller: controller,
                             store: store
                         )
-                        .allowsHitTesting(
-                            controller.showPrompt ||
-                            controller.showSave ||
-                            controller.sessionExpired
-                        )
+                        .allowsHitTesting(controller.hasInteractiveOverlayContent)
                     }
                 }
 

--- a/macos/Tests/BrowserAutofillTests.swift
+++ b/macos/Tests/BrowserAutofillTests.swift
@@ -159,6 +159,48 @@ struct BrowserAutofillTests {
         #expect(invocations == [["vault", "list", "--output", "json"]])
     }
 
+    @MainActor
+    @Test("CLI discovery populates vault names for save-first flows")
+    func cliDiscoveryBackfillsVaultNamesForSaveFirstFlows() async throws {
+        let store = AutofillStore(
+            vaultName: nil,
+            passCLIPath: nil,
+            autoDiscoverCLI: true,
+            processRunner: { _, arguments, _ in
+                switch arguments {
+                case ["-l", "-c", "which pass-cli"]:
+                    return AutofillProcessResult(
+                        output: "/usr/bin/pass-cli\n",
+                        stderr: "",
+                        exitCode: 0
+                    )
+                case ["test"]:
+                    return AutofillProcessResult(
+                        output: "",
+                        stderr: "",
+                        exitCode: 0
+                    )
+                case ["vault", "list", "--output", "json"]:
+                    return AutofillProcessResult(
+                        output: #"{"vaults":[{"name":"Personal"},{"name":"Work"}]}"#,
+                        stderr: "",
+                        exitCode: 0
+                    )
+                default:
+                    Issue.record("Unexpected process invocation: \(arguments)")
+                    return AutofillProcessResult(output: "", stderr: "unexpected", exitCode: 1)
+                }
+            }
+        )
+
+        for _ in 0..<20 {
+            if !store.availableVaultNames.isEmpty { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        #expect(store.availableVaultNames == ["Personal", "Work"])
+    }
+
     @Test("TOTP cleanup only clears clipboard when the same code is still present")
     func totpCleanupChecksClipboardContents() async throws {
         #expect(BrowserAutofillController.shouldClearTOTPPasteboard(

--- a/macos/Tests/BrowserAutofillTests.swift
+++ b/macos/Tests/BrowserAutofillTests.swift
@@ -1,0 +1,125 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Ghostty
+
+@Suite("Browser Autofill")
+struct BrowserAutofillTests {
+    @Test("runProcess drains large stdout and stderr before returning")
+    func runProcessDrainsLargeOutput() async throws {
+        let stdoutChunk = String(repeating: "o", count: 80_000)
+        let stderrChunk = String(repeating: "e", count: 80_000)
+        let script = "import sys; sys.stdout.write('\(stdoutChunk)'); sys.stderr.write('\(stderrChunk)')"
+
+        let result = await AutofillStore.runProcessForTesting(
+            executable: "/usr/bin/python3",
+            arguments: ["-c", script],
+            input: nil
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.output == stdoutChunk)
+        #expect(result.stderr == stderrChunk)
+    }
+
+    @MainActor
+    @Test("store refresh loads vault names, matches normalized hosts, and resolves share IDs back to vault names")
+    func storeRefreshTracksVaultNamesAndShareIds() async throws {
+        var invocations: [[String]] = []
+        let store = AutofillStore(
+            vaultName: nil,
+            passCLIPath: "/usr/bin/pass-cli",
+            autoDiscoverCLI: false,
+            processRunner: { _, arguments, _ in
+                invocations.append(arguments)
+
+                switch arguments {
+                case ["vault", "list", "--output", "json"]:
+                    return AutofillProcessResult(
+                        output: #"{"vaults":[{"name":"Personal"},{"name":"Work"}]}"#,
+                        stderr: "",
+                        exitCode: 0
+                    )
+                case ["item", "list", "Personal", "--filter-type", "login", "--output", "json"]:
+                    return AutofillProcessResult(
+                        output: #"""
+                        {"items":[{"id":"item-1","share_id":"share-personal","state":"Active","content":{"title":"Example","content":{"Login":{"email":"alice@example.com","username":"","password":"secret","urls":["https://www.example.com/login"],"totp_uri":""}}}}]}
+                        """#,
+                        stderr: "",
+                        exitCode: 0
+                    )
+                case ["item", "list", "Work", "--filter-type", "login", "--output", "json"]:
+                    return AutofillProcessResult(
+                        output: #"{"items":[]}"#,
+                        stderr: "",
+                        exitCode: 0
+                    )
+                case ["item", "view", "--item-id", "item-1", "--output", "json", "--vault-name", "Personal"]:
+                    return AutofillProcessResult(
+                        output: #"""
+                        {"content":{"content":{"Login":{"username":"alice","email":"alice@example.com","password":"secret"}}}}
+                        """#,
+                        stderr: "",
+                        exitCode: 0
+                    )
+                default:
+                    Issue.record("Unexpected process invocation: \(arguments)")
+                    return AutofillProcessResult(output: "", stderr: "unexpected", exitCode: 1)
+                }
+            }
+        )
+
+        let matches = await store.findMatches(for: try #require(URL(string: "https://example.com/account")))
+
+        #expect(matches.count == 1)
+        #expect(matches.first?.shareId == "share-personal")
+        #expect(store.availableVaultNames == ["Personal", "Work"])
+
+        _ = await store.fetchCredential(shareId: "share-personal", itemId: "item-1")
+
+        #expect(invocations.contains(["item", "view", "--item-id", "item-1", "--output", "json", "--vault-name", "Personal"]))
+    }
+
+    @MainActor
+    @Test("submit suppression resets on navigation instead of leaking into later saves")
+    func submitSuppressionResetsOnNavigation() async throws {
+        let controller = BrowserAutofillController(store: AutofillStore(
+            vaultName: "Personal",
+            passCLIPath: "/usr/bin/pass-cli",
+            autoDiscoverCLI: false,
+            processRunner: { _, _, _ in
+                AutofillProcessResult(output: "", stderr: "", exitCode: 0)
+            }
+        ))
+
+        controller.autofillDidFill = true
+        controller.consumeSubmitDetected(isNewPassword: true, username: "alice", password: "secret", domain: "example.com")
+
+        #expect(controller.showSave == false)
+        #expect(controller.autofillDidFill == false)
+
+        controller.autofillDidFill = true
+        controller.handleNavigation(to: URL(string: "https://example.com/other"))
+        controller.consumeSubmitDetected(isNewPassword: true, username: "alice", password: "secret", domain: "example.com")
+
+        #expect(controller.autofillDidFill == false)
+        #expect(controller.showSave == true)
+        #expect(controller.pendingSavePassword == "secret")
+    }
+
+    @Test("TOTP cleanup only clears clipboard when the same code is still present")
+    func totpCleanupChecksClipboardContents() async throws {
+        #expect(BrowserAutofillController.shouldClearTOTPPasteboard(
+            currentString: "123456",
+            expectedTOTP: "123456"
+        ) == true)
+        #expect(BrowserAutofillController.shouldClearTOTPPasteboard(
+            currentString: "different",
+            expectedTOTP: "123456"
+        ) == false)
+        #expect(BrowserAutofillController.shouldClearTOTPPasteboard(
+            currentString: nil,
+            expectedTOTP: "123456"
+        ) == false)
+    }
+}

--- a/macos/Tests/BrowserAutofillTests.swift
+++ b/macos/Tests/BrowserAutofillTests.swift
@@ -107,6 +107,58 @@ struct BrowserAutofillTests {
         #expect(controller.pendingSavePassword == "secret")
     }
 
+    @MainActor
+    @Test("fill error alone still counts as interactive overlay content")
+    func fillErrorMakesOverlayInteractive() async throws {
+        let controller = BrowserAutofillController(store: AutofillStore(
+            vaultName: "Personal",
+            passCLIPath: "/usr/bin/pass-cli",
+            autoDiscoverCLI: false,
+            processRunner: { _, _, _ in
+                AutofillProcessResult(output: "", stderr: "", exitCode: 0)
+            }
+        ))
+
+        #expect(controller.hasInteractiveOverlayContent == false)
+        controller.fillErrorMessage = "Could not fill"
+        #expect(controller.hasInteractiveOverlayContent == true)
+        controller.dismissFillError()
+        #expect(controller.hasInteractiveOverlayContent == false)
+    }
+
+    @MainActor
+    @Test("save-first flows can load vault names before any match refresh")
+    func ensureVaultNamesLoadedSupportsSaveFirstFlows() async throws {
+        var invocations: [[String]] = []
+        let store = AutofillStore(
+            vaultName: nil,
+            passCLIPath: "/usr/bin/pass-cli",
+            autoDiscoverCLI: false,
+            processRunner: { _, arguments, _ in
+                invocations.append(arguments)
+
+                switch arguments {
+                case ["vault", "list", "--output", "json"]:
+                    return AutofillProcessResult(
+                        output: #"{"vaults":[{"name":"Personal"},{"name":"Work"}]}"#,
+                        stderr: "",
+                        exitCode: 0
+                    )
+                default:
+                    Issue.record("Unexpected process invocation: \(arguments)")
+                    return AutofillProcessResult(output: "", stderr: "unexpected", exitCode: 1)
+                }
+            }
+        )
+
+        #expect(store.availableVaultNames.isEmpty)
+
+        await store.ensureVaultNamesLoaded()
+
+        #expect(store.availableVaultNames == ["Personal", "Work"])
+        #expect(invocations == [["vault", "list", "--output", "json"]])
+    }
+
     @Test("TOTP cleanup only clears clipboard when the same code is still present")
     func totpCleanupChecksClipboardContents() async throws {
         #expect(BrowserAutofillController.shouldClearTOTPPasteboard(


### PR DESCRIPTION
## Summary
- tighten browser autofill state handling
- unblock save-first, error-banner, vault backfill, and store initialization flows
- address the autofill issue set for #1 through #6 on top of the clean foundation in #80

## Related Issues
- Addresses #1
- Addresses #2
- Addresses #3
- Addresses #4
- Addresses #5
- Addresses #6

## Related PRs
- depends on #79
- depends on #80

## macOS Test Plan
- `xcodebuild test -project macos/Ghostty.xcodeproj -scheme Ghostty -configuration Debug SYMROOT=macos/build -skip-testing GhosttyUITests -only-testing:GhosttyTests/BrowserAutofillTests`

## Linux Test Plan
- Not run; browser autofill changes are macOS-only.