### PR TITLE
[codex] Fix browser socket issues (#70-#74)

### DIFF
--- a/macos/Sources/Features/Browser/BrowserProxyRelay.swift
+++ b/macos/Sources/Features/Browser/BrowserProxyRelay.swift
@@ -138,7 +138,7 @@ class BrowserProxyRelay {
         let connectStart = Date()
         let remote: NWConnection
 
-        if let upstream = _upstreamProxy, let (proxyHost, proxyPort) = parseProxyURL(upstream) {
+        if let upstream = _upstreamProxy, let (proxyHost, proxyPort) = Self.parseProxyURL(upstream) {
             // Connect to upstream proxy and forward the CONNECT request
             remote = NWConnection(host: NWEndpoint.Host(proxyHost), port: NWEndpoint.Port(integerLiteral: proxyPort), using: .tcp)
         } else {
@@ -155,7 +155,7 @@ class BrowserProxyRelay {
             case .ready:
                 let connectDuration = Date().timeIntervalSince(connectStart)
 
-                if let upstream = self?._upstreamProxy, self?.parseProxyURL(upstream) != nil {
+                if let upstream = self?._upstreamProxy, Self.parseProxyURL(upstream) != nil {
                     // When going through upstream proxy, forward the CONNECT request
                     let connectRequest = "CONNECT \(target) HTTP/1.1\r\nHost: \(target)\r\n\r\n"
                     remote.send(content: connectRequest.data(using: .utf8), completion: .contentProcessed { [weak self] _ in
@@ -223,7 +223,7 @@ class BrowserProxyRelay {
         let sendStart = Date()
         let remote: NWConnection
 
-        if let upstream = _upstreamProxy, let (proxyHost, proxyPort) = parseProxyURL(upstream) {
+        if let upstream = _upstreamProxy, let (proxyHost, proxyPort) = Self.parseProxyURL(upstream) {
             // Forward entire request to upstream proxy as-is
             remote = NWConnection(host: NWEndpoint.Host(proxyHost), port: NWEndpoint.Port(integerLiteral: proxyPort), using: .tcp)
         } else {
@@ -316,8 +316,11 @@ class BrowserProxyRelay {
         return (target, defaultPort)
     }
 
-    private func parseProxyURL(_ urlString: String) -> (String, UInt16)? {
-        guard let url = URL(string: urlString), let host = url.host else { return nil }
+    static func parseProxyURL(_ urlString: String) -> (String, UInt16)? {
+        guard let url = URL(string: urlString),
+              let scheme = url.scheme,
+              !scheme.isEmpty,
+              let host = url.host else { return nil }
         let port = UInt16(url.port ?? 8080)
         return (host, port)
     }

--- a/macos/Sources/Features/Browser/BrowserSocketServer.swift
+++ b/macos/Sources/Features/Browser/BrowserSocketServer.swift
@@ -599,7 +599,7 @@ private extension BrowserSocketServer {
         }
 
         if (statInfo.st_mode & S_IFMT) != S_IFSOCK {
-            return true
+            return false
         }
 
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)

--- a/macos/Sources/Features/Browser/BrowserSocketServer.swift
+++ b/macos/Sources/Features/Browser/BrowserSocketServer.swift
@@ -4,6 +4,8 @@ import Foundation
 /// Unix domain socket server that accepts newline-delimited JSON commands
 /// and returns JSON responses. Used for programmatic control of a browser pane.
 class BrowserSocketServer {
+    static let socketDirectory = URL(fileURLWithPath: "/tmp/trident", isDirectory: true)
+
     let socketPath: String
     let paneId: UUID
     private var socketFD: Int32 = -1
@@ -25,7 +27,7 @@ class BrowserSocketServer {
         self.paneId = paneId
         // Use /tmp/trident/ instead of $TMPDIR — macOS $TMPDIR paths are
         // too long (60+ chars) and Unix socket paths are limited to 104 bytes.
-        let tmpDir = URL(fileURLWithPath: "/tmp/trident", isDirectory: true)
+        let tmpDir = Self.socketDirectory
         try? FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         // Use first 8 chars of UUID to keep path short
         let shortId = String(paneId.uuidString.prefix(8)).lowercased()
@@ -39,6 +41,8 @@ class BrowserSocketServer {
     // MARK: - Lifecycle
 
     func start() throws {
+        Self.removeDeadSocketFiles(excluding: socketPath)
+
         // Remove stale socket file if present
         unlink(socketPath)
 
@@ -199,6 +203,10 @@ class BrowserSocketServer {
 
     // MARK: - Command Handling
 
+    private func noActiveModelResponse() -> [String: Any] {
+        ["ok": false, "error": "no active browser model"]
+    }
+
     /// Handle a JSON command dictionary and return a response dictionary.
     /// Called on the main thread so WKWebView access is safe.
     private func handleCommand(_ command: [String: Any]) -> [String: Any] {
@@ -241,6 +249,18 @@ class BrowserSocketServer {
             let sem = DispatchSemaphore(value: 0)
             DispatchQueue.main.async { [weak self] in
                 self?.activeModel?.reload()
+                sem.signal()
+            }
+            sem.wait()
+            return ["ok": true]
+
+        case "stop":
+            guard let model = activeModel else {
+                return noActiveModelResponse()
+            }
+            let sem = DispatchSemaphore(value: 0)
+            DispatchQueue.main.async {
+                model.stopLoading()
                 sem.signal()
             }
             sem.wait()
@@ -434,9 +454,15 @@ class BrowserSocketServer {
 
         case "proxy_set":
             let url = command["url"] as? String
+            if let url, BrowserProxyRelay.parseProxyURL(url) == nil {
+                return ["ok": false, "error": "invalid proxy URL"]
+            }
+            guard let model = activeModel else {
+                return noActiveModelResponse()
+            }
             let sem = DispatchSemaphore(value: 0)
-            DispatchQueue.main.async { [weak self] in
-                self?.activeModel?.setProxy(url)
+            DispatchQueue.main.async {
+                model.setProxy(url)
                 sem.signal()
             }
             sem.wait()
@@ -545,5 +571,63 @@ class BrowserSocketServer {
         case pathTooLong
         case bindFailed(errno: Int32)
         case listenFailed(errno: Int32)
+    }
+}
+
+private extension BrowserSocketServer {
+    static func removeDeadSocketFiles(excluding currentPath: String) {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: socketDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for entry in entries where entry.lastPathComponent.hasPrefix("b-") && entry.pathExtension == "sock" {
+            let path = entry.path
+            guard path != currentPath else { continue }
+            guard shouldRemoveSocket(at: path) else { continue }
+            unlink(path)
+        }
+    }
+
+    static func shouldRemoveSocket(at path: String) -> Bool {
+        var statInfo = stat()
+        if lstat(path, &statInfo) != 0 {
+            return false
+        }
+
+        if (statInfo.st_mode & S_IFMT) != S_IFSOCK {
+            return true
+        }
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { Darwin.close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = path.utf8CString.map(UInt8.init(bitPattern:))
+        withUnsafeMutableBytes(of: &addr.sun_path) { bytes in
+            bytes.copyBytes(from: pathBytes)
+        }
+        addr.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        if result == 0 {
+            return false
+        }
+
+        switch errno {
+        case ECONNREFUSED, ENOENT, ENOTSOCK:
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/macos/Sources/Features/Browser/BrowserTabManager.swift
+++ b/macos/Sources/Features/Browser/BrowserTabManager.swift
@@ -70,8 +70,15 @@ class BrowserTabManager: ObservableObject {
     }
 
     deinit {
+        invalidate()
+    }
+
+    func invalidate() {
         socketServer?.stop()
+        socketServer = nil
         proxyRelay?.stop()
+        proxyRelay = nil
+        onLastTabClosed = nil
     }
 
     // MARK: - Tab Management

--- a/macos/Sources/Ghostty/Surface View/BrowsableSurface.swift
+++ b/macos/Sources/Ghostty/Surface View/BrowsableSurface.swift
@@ -60,7 +60,14 @@ extension Ghostty {
         }
 
         private func onToggleBrowser() {
-            // Ensure tab manager exists before showing, with config from ghostty
+            if surfaceView.browserVisible {
+                hideBrowser()
+            } else {
+                showBrowser()
+            }
+        }
+
+        private func showBrowser() {
             if surfaceView.browserTabManager == nil {
                 let manager = BrowserTabManager(
                     proxyURL: ghostty.config.browserProxy,
@@ -68,11 +75,22 @@ extension Ghostty {
                     tlsStrict: ghostty.config.browserTlsStrict
                 )
                 manager.onLastTabClosed = { [weak surfaceView] in
-                    surfaceView?.browserVisible = false
+                    guard let surfaceView else { return }
+                    let manager = surfaceView.browserTabManager
+                    surfaceView.browserVisible = false
+                    surfaceView.browserTabManager = nil
+                    manager?.invalidate()
                 }
                 surfaceView.browserTabManager = manager
             }
-            surfaceView.browserVisible.toggle()
+            surfaceView.browserVisible = true
+        }
+
+        private func hideBrowser() {
+            let manager = surfaceView.browserTabManager
+            surfaceView.browserVisible = false
+            surfaceView.browserTabManager = nil
+            manager?.invalidate()
         }
     }
 }

--- a/macos/Tests/Browser/BrowserSocketServerTests.swift
+++ b/macos/Tests/Browser/BrowserSocketServerTests.swift
@@ -49,7 +49,12 @@ struct BrowserSocketServerTests {
 
     @Test func startRemovesDeadBrowserSocketFiles() throws {
         let stalePath = "/tmp/trident/b-deadbeef.sock"
-        _ = FileManager.default.createFile(atPath: stalePath, contents: Data())
+        try FileManager.default.createDirectory(
+            atPath: "/tmp/trident",
+            withIntermediateDirectories: true
+        )
+        try BrowserSocketFixture.createDeadSocket(at: stalePath)
+        #expect(FileManager.default.fileExists(atPath: stalePath))
         defer { unlink(stalePath) }
 
         let server = BrowserSocketServer(paneId: UUID())
@@ -121,5 +126,34 @@ private enum BrowserSocketTestClient {
         let responseData = Data(prefix[0..<newlineIndex])
         let object = try JSONSerialization.jsonObject(with: responseData)
         return object as? [String: Any] ?? [:]
+    }
+}
+
+private enum BrowserSocketFixture {
+    static func createDeadSocket(at path: String) throws {
+        unlink(path)
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(.EIO)
+        }
+        defer { Darwin.close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = path.utf8CString.map(UInt8.init(bitPattern:))
+        withUnsafeMutableBytes(of: &addr.sun_path) { bytes in
+            bytes.copyBytes(from: pathBytes)
+        }
+        addr.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                bind(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
     }
 }

--- a/macos/Tests/Browser/BrowserSocketServerTests.swift
+++ b/macos/Tests/Browser/BrowserSocketServerTests.swift
@@ -1,0 +1,125 @@
+import Darwin
+import Foundation
+import Testing
+@testable import Ghostty
+
+@Suite(.serialized)
+struct BrowserSocketServerTests {
+    @Test func stopCommandWithoutActiveModelReturnsClearError() throws {
+        let server = BrowserSocketServer(paneId: UUID())
+        try server.start()
+        defer { server.stop() }
+
+        let response = try BrowserSocketTestClient.send(
+            ["cmd": "stop"],
+            to: server.socketPath
+        )
+
+        #expect(response["ok"] as? Bool == false)
+        #expect(response["error"] as? String == "no active browser model")
+    }
+
+    @Test func invalidProxyURLIsRejectedBeforeMutation() throws {
+        let server = BrowserSocketServer(paneId: UUID())
+        try server.start()
+        defer { server.stop() }
+
+        let response = try BrowserSocketTestClient.send(
+            ["cmd": "proxy_set", "url": "not-a-url"],
+            to: server.socketPath
+        )
+
+        #expect(response["ok"] as? Bool == false)
+        #expect(response["error"] as? String == "invalid proxy URL")
+    }
+
+    @Test func validProxyURLStillNeedsActiveBrowserModel() throws {
+        let server = BrowserSocketServer(paneId: UUID())
+        try server.start()
+        defer { server.stop() }
+
+        let response = try BrowserSocketTestClient.send(
+            ["cmd": "proxy_set", "url": "http://127.0.0.1:8080"],
+            to: server.socketPath
+        )
+
+        #expect(response["ok"] as? Bool == false)
+        #expect(response["error"] as? String == "no active browser model")
+    }
+
+    @Test func startRemovesDeadBrowserSocketFiles() throws {
+        let stalePath = "/tmp/trident/b-deadbeef.sock"
+        _ = FileManager.default.createFile(atPath: stalePath, contents: Data())
+        defer { unlink(stalePath) }
+
+        let server = BrowserSocketServer(paneId: UUID())
+        try server.start()
+        defer { server.stop() }
+
+        #expect(FileManager.default.fileExists(atPath: stalePath) == false)
+    }
+
+    @Test func invalidatingTabManagerStopsOldSocketBeforeReplacement() throws {
+        let manager = BrowserTabManager()
+        let oldSocketPath = try #require(manager.socketServer?.socketPath)
+        #expect(FileManager.default.fileExists(atPath: oldSocketPath))
+
+        manager.invalidate()
+        #expect(FileManager.default.fileExists(atPath: oldSocketPath) == false)
+
+        let replacement = BrowserTabManager()
+        defer { replacement.invalidate() }
+        let newSocketPath = try #require(replacement.socketServer?.socketPath)
+        #expect(newSocketPath != oldSocketPath)
+        #expect(FileManager.default.fileExists(atPath: newSocketPath))
+    }
+}
+
+private enum BrowserSocketTestClient {
+    static func send(_ command: [String: Any], to socketPath: String) throws -> [String: Any] {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(.EIO)
+        }
+        defer { Darwin.close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketPath.utf8CString.map(UInt8.init(bitPattern:))
+        withUnsafeMutableBytes(of: &addr.sun_path) { bytes in
+            bytes.copyBytes(from: pathBytes)
+        }
+        addr.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                connect(fd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connectResult == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .ECONNREFUSED)
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: command)
+        var payload = data
+        payload.append(0x0A)
+        let writeResult = payload.withUnsafeBytes { bytes in
+            write(fd, bytes.baseAddress, bytes.count)
+        }
+        guard writeResult == payload.count else {
+            throw POSIXError(.EIO)
+        }
+
+        var readBuffer = [UInt8](repeating: 0, count: 4096)
+        let bytesRead = read(fd, &readBuffer, readBuffer.count)
+        guard bytesRead > 0 else {
+            throw POSIXError(.EIO)
+        }
+
+        let prefix = Array(readBuffer[0..<bytesRead])
+        let newlineIndex = prefix.firstIndex(of: 0x0A) ?? prefix.endIndex
+        let responseData = Data(prefix[0..<newlineIndex])
+        let object = try JSONSerialization.jsonObject(with: responseData)
+        return object as? [String: Any] ?? [:]
+    }
+}


### PR DESCRIPTION
## Summary
- validate browser proxy URL updates before mutation
- stop and replace stale browser sockets cleanly
- address the browser issue set for #70 through #74

## Related Issues
- Addresses #70
- Addresses #71
- Addresses #72
- Addresses #73
- Addresses #74

## Related PRs
- depends on #79

## macOS Test Plan
- `xcodebuild test -project macos/Ghostty.xcodeproj -scheme Ghostty -configuration Debug SYMROOT=macos/build -skip-testing GhosttyUITests -only-testing:GhosttyTests/BrowserSocketServerTests`

## Linux Test Plan
- Not run; browser socket server changes are macOS-only.