### PR TITLE
[codex] Extract autofill foundation for issue-fix review

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ghostty,
-    .version = "1.3.2-dev",
+    .version = "1.3.4-dev",
     .paths = .{""},
     .fingerprint = 0x64407a2a0b4147e5,
     .minimum_zig_version = "0.15.2",

--- a/macos/Sources/Features/Browser/Autofill/AutofillOverlayView.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillOverlayView.swift
@@ -1,0 +1,263 @@
+import SwiftUI
+
+// MARK: - AutofillOverlayView
+
+/// Full-width overlay positioned at the top of the web content area.
+/// Renders whichever autofill UI state is active for the current tab.
+struct AutofillOverlayView: View {
+    @ObservedObject var controller: BrowserAutofillController
+    var availableVaults: [String]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if controller.sessionExpired {
+                SessionExpiredBanner(controller: controller)
+            }
+
+            if controller.showPrompt, !controller.matchingCredentials.isEmpty {
+                CredentialPickerView(controller: controller)
+            }
+
+            if let code = controller.totpCode {
+                TOTPToastView(code: code)
+            }
+
+            if controller.showSave {
+                SavePromptView(
+                    controller: controller,
+                    availableVaults: availableVaults
+                )
+            }
+
+            Spacer()
+        }
+    }
+}
+
+// MARK: - SessionExpiredBanner
+
+private struct SessionExpiredBanner: View {
+    @ObservedObject var controller: BrowserAutofillController
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "lock.fill")
+                .foregroundColor(.orange)
+            Text("Proton Pass session expired — run `pass-cli login` in a terminal")
+                .font(.system(size: 12))
+                .foregroundColor(.primary)
+            Spacer()
+            Button(action: { controller.sessionExpired = false }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 0)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .overlay(
+                    Rectangle()
+                        .fill(Color.orange)
+                        .frame(height: 2),
+                    alignment: .bottom
+                )
+        )
+    }
+}
+
+// MARK: - CredentialPickerView
+
+private struct CredentialPickerView: View {
+    @ObservedObject var controller: BrowserAutofillController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Image(systemName: "key.fill")
+                    .foregroundColor(.accentColor)
+                    .font(.system(size: 11))
+                Text("Proton Pass")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Button(action: { controller.dismissPrompt() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
+
+            ForEach(controller.matchingCredentials) { credential in
+                Button(action: { controller.fill(credential: credential) }) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "person.fill")
+                            .foregroundColor(.accentColor)
+                            .frame(width: 16)
+
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(credential.title)
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundColor(.primary)
+                            Text(credential.displayLabel)
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
+                        }
+
+                        Spacer()
+
+                        if credential.hasTOTP {
+                            Image(systemName: "clock.badge.checkmark")
+                                .font(.system(size: 10))
+                                .foregroundColor(.secondary)
+                                .help("Includes TOTP — code will be copied to clipboard")
+                        }
+                    }
+                    .contentShape(Rectangle())
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                }
+                .buttonStyle(.plain)
+
+                if credential.id != controller.matchingCredentials.last?.id {
+                    Divider().padding(.horizontal, 12)
+                }
+            }
+
+            Spacer().frame(height: 6)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 0)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+        )
+    }
+}
+
+// MARK: - TOTPToastView
+
+private struct TOTPToastView: View {
+    let code: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .font(.system(size: 12))
+            Text("TOTP copied to clipboard")
+                .font(.system(size: 12))
+                .foregroundColor(.primary)
+            Text("(\(code))")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 0)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+    }
+}
+
+// MARK: - SavePromptView
+
+private struct SavePromptView: View {
+    @ObservedObject var controller: BrowserAutofillController
+    let availableVaults: [String]
+
+    @State private var editableTitle: String = ""
+    @State private var editableUsername: String = ""
+    @State private var selectedVault: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "plus.circle.fill")
+                    .foregroundColor(.accentColor)
+                    .font(.system(size: 11))
+                Text("Save to Proton Pass?")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Button(action: { controller.dismissSave() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10))
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Title")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                    TextField("Login title", text: $editableTitle)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12))
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Username / Email")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+                    TextField("username", text: $editableUsername)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12))
+                }
+            }
+
+            if availableVaults.count > 1 {
+                HStack(spacing: 8) {
+                    Text("Vault:")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                    Picker("", selection: $selectedVault) {
+                        ForEach(availableVaults, id: \.self) { name in
+                            Text(name).tag(name)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(maxWidth: 160)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Not now") {
+                    controller.dismissSave()
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+
+                Button("Save") {
+                    controller.saveCredential(
+                        title: editableTitle,
+                        username: editableUsername,
+                        vaultName: selectedVault
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+                .font(.system(size: 12))
+                .disabled(editableTitle.isEmpty || selectedVault.isEmpty)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 0)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
+        )
+        .onAppear {
+            editableTitle = controller.pendingSaveTitle
+            editableUsername = controller.pendingSaveUsername
+            selectedVault = availableVaults.first ?? ""
+        }
+    }
+}

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -1,0 +1,431 @@
+import Foundation
+
+// MARK: - PassCredentialMeta
+
+/// Metadata extracted from a single Proton Pass login item.
+/// Passwords and TOTP secrets are NEVER stored here — only the
+/// minimum needed for URL matching and display in the picker.
+struct PassCredentialMeta: Identifiable {
+    /// Globally unique item identifier within this vault.
+    let itemId: String
+    /// The vault share ID that owns this item.
+    let shareId: String
+    /// Human-readable title from the Proton Pass item.
+    let title: String
+    /// All URLs associated with this login item.
+    let urls: [String]
+    /// Email address (may be empty string).
+    let email: String
+    /// Username (may be empty string).
+    let username: String
+    /// True if the item has a non-empty totp_uri (TOTP secret is NOT stored).
+    let hasTOTP: Bool
+
+    var id: String { "\(shareId)/\(itemId)" }
+
+    /// Returns the display label: email if non-empty, else username, else title.
+    var displayLabel: String {
+        if !email.isEmpty { return email }
+        if !username.isEmpty { return username }
+        return title
+    }
+}
+
+// MARK: - VaultIndex
+
+/// In-memory cache of Proton Pass login metadata.
+/// Never holds passwords or TOTP secrets.
+private struct VaultIndex {
+    var items: [PassCredentialMeta] = []
+    var loadedAt: Date?
+
+    var isStale: Bool {
+        guard let loadedAt else { return true }
+        return Date().timeIntervalSince(loadedAt) > 300 // 5-minute TTL
+    }
+}
+
+// MARK: - AutofillStore
+
+/// Shared across all browser tabs. Owns the vault metadata cache and
+/// all pass-cli subprocess calls. All subprocess calls run off the main
+/// thread via async/await with a TaskGroup-style detached Task.
+///
+/// Analogy: think of this like a DNS cache — it keeps a fast in-memory
+/// index of what's in the vault and only reaches out to the real store
+/// when it needs to resolve a specific secret.
+@MainActor
+final class AutofillStore: ObservableObject {
+
+    // MARK: - Published State
+
+    /// True when pass-cli is not installed or session has expired.
+    @Published private(set) var isUnavailable: Bool = false
+    /// Human-readable reason autofill is unavailable (for banner display).
+    @Published private(set) var unavailableReason: String = ""
+
+    // MARK: - Private State
+
+    private var index = VaultIndex()
+    private var passCLIPath: String?
+    /// Optional vault name to restrict lookups. Nil = all vaults.
+    private let vaultName: String?
+
+    // MARK: - Init
+
+    /// Discover pass-cli and record the optional vault restriction.
+    /// - Parameter vaultName: Vault to restrict to, or nil for all vaults.
+    init(vaultName: String?) {
+        self.vaultName = vaultName
+        Task { await discoverCLI() }
+    }
+
+    // MARK: - CLI Discovery
+
+    private func discoverCLI() async {
+        let found = await runProcess(
+            executable: "/usr/bin/which",
+            arguments: ["pass-cli"],
+            input: nil
+        )
+        let trimmed = found.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || found.exitCode != 0 {
+            print("[AutofillStore] pass-cli not found — autofill disabled")
+            isUnavailable = true
+            unavailableReason = "pass-cli not found in PATH"
+            return
+        }
+        passCLIPath = trimmed
+        print("[AutofillStore] pass-cli discovered at: \(trimmed)")
+        await checkSession()
+    }
+
+    // MARK: - Session Check
+
+    /// Runs `pass-cli test` to verify the session is active.
+    /// Sets isUnavailable if the session is expired.
+    func checkSession() async {
+        guard let cli = passCLIPath else { return }
+        let result = await runProcess(executable: cli, arguments: ["test"], input: nil)
+        if result.exitCode != 0 {
+            print("[AutofillStore] pass-cli session expired")
+            isUnavailable = true
+            unavailableReason = "Proton Pass session expired — run `pass-cli login` in a terminal"
+        } else {
+            isUnavailable = false
+            unavailableReason = ""
+        }
+    }
+
+    // MARK: - URL Matching
+
+    /// Find all cached credentials that match the given URL.
+    /// Performs exact-host matching with www-prefix stripping.
+    /// Returns empty array if autofill is unavailable or URL is not HTTPS.
+    func findMatches(for pageURL: URL) async -> [PassCredentialMeta] {
+        guard !isUnavailable else { return [] }
+
+        // HTTPS enforcement — never autofill on plain HTTP
+        guard pageURL.scheme?.lowercased() == "https" else {
+            print("[AutofillStore] Skipping autofill on non-HTTPS URL: \(pageURL)")
+            return []
+        }
+
+        // Refresh index if stale
+        if index.isStale {
+            await refreshIndex()
+        }
+
+        guard let pageHost = normalizeHost(pageURL.host) else { return [] }
+
+        return index.items.filter { item in
+            item.urls.contains { urlStr in
+                guard let url = URL(string: urlStr),
+                      let itemHost = normalizeHost(url.host) else { return false }
+                return itemHost == pageHost
+            }
+        }
+    }
+
+    // MARK: - Index Refresh
+
+    /// Re-loads the vault index from pass-cli. Called when index is stale.
+    private func refreshIndex() async {
+        guard let cli = passCLIPath else { return }
+
+        print("[AutofillStore] Refreshing vault index...")
+
+        // Determine which vault(s) to load
+        var vaultNames: [String] = []
+        if let name = vaultName {
+            vaultNames = [name]
+        } else {
+            // Enumerate all vaults
+            let result = await runProcess(
+                executable: cli,
+                arguments: ["vault", "list", "--output", "json"],
+                input: nil
+            )
+            if result.exitCode != 0 {
+                print("[AutofillStore] vault list failed: \(result.stderr)")
+                await checkSession()
+                return
+            }
+            guard let data = result.output.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let vaults = json["vaults"] as? [[String: Any]] else {
+                print("[AutofillStore] Failed to parse vault list JSON")
+                return
+            }
+            vaultNames = vaults.compactMap { $0["name"] as? String }
+        }
+
+        // Load items from each vault and merge
+        var allItems: [PassCredentialMeta] = []
+        for name in vaultNames {
+            let result = await runProcess(
+                executable: cli,
+                arguments: ["item", "list", name, "--filter-type", "login", "--output", "json"],
+                input: nil
+            )
+            if result.exitCode != 0 {
+                print("[AutofillStore] item list for vault '\(name)' failed: \(result.stderr)")
+                continue
+            }
+            let parsed = parseItemList(result.output)
+            allItems.append(contentsOf: parsed)
+        }
+
+        index.items = allItems
+        index.loadedAt = Date()
+        print("[AutofillStore] Index loaded: \(allItems.count) login item(s)")
+    }
+
+    // MARK: - JSON Parsing
+
+    /// Parse the JSON array returned by `pass-cli item list`.
+    /// Extracts metadata only — passwords and totp_uri are discarded after
+    /// the hasTOTP boolean is derived.
+    private func parseItemList(_ jsonString: String) -> [PassCredentialMeta] {
+        guard let data = jsonString.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+
+        return array.compactMap { item -> PassCredentialMeta? in
+            guard let itemId = item["id"] as? String,
+                  let shareId = item["share_id"] as? String,
+                  let content = item["content"] as? [String: Any],
+                  let title = content["title"] as? String,
+                  let innerContent = content["content"] as? [String: Any],
+                  let login = innerContent["Login"] as? [String: Any] else {
+                return nil
+            }
+
+            let email = login["email"] as? String ?? ""
+            let username = login["username"] as? String ?? ""
+            let urls = login["urls"] as? [String] ?? []
+            let totpURI = login["totp_uri"] as? String ?? ""
+            let hasTOTP = !totpURI.isEmpty
+
+            // State filter — only Active items
+            let state = item["state"] as? String ?? "Active"
+            guard state == "Active" else { return nil }
+
+            return PassCredentialMeta(
+                itemId: itemId,
+                shareId: shareId,
+                title: title,
+                urls: urls,
+                email: email,
+                username: username,
+                hasTOTP: hasTOTP
+            )
+        }
+    }
+
+    // MARK: - Lazy Secret Fetch
+
+    /// Fetch the full credential (username + password) for a given item.
+    /// Secrets are fetched on demand and should be used immediately, not stored.
+    /// Returns nil if the fetch fails.
+    func fetchCredential(shareId: String, itemId: String) async -> (username: String, email: String, password: String)? {
+        guard let cli = passCLIPath else { return nil }
+
+        let vaultArg = vaultNameForShareId(shareId)
+
+        var args = ["item", "view", "--item-id", itemId, "--output", "json"]
+        if let vault = vaultArg {
+            args += ["--vault-name", vault]
+        }
+
+        let result = await runProcess(executable: cli, arguments: args, input: nil)
+        guard result.exitCode == 0,
+              let data = result.output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [String: Any],
+              let innerContent = content["content"] as? [String: Any],
+              let login = innerContent["Login"] as? [String: Any] else {
+            print("[AutofillStore] fetchCredential failed: \(result.stderr)")
+            return nil
+        }
+
+        let username = login["username"] as? String ?? ""
+        let email = login["email"] as? String ?? ""
+        let password = login["password"] as? String ?? ""
+
+        return (username: username, email: email, password: password)
+    }
+
+    // MARK: - TOTP Fetch
+
+    /// Fetch a TOTP code for an item with hasTOTP = true.
+    /// Returns nil if the item has no TOTP or the fetch fails.
+    func fetchTOTP(shareId: String, itemId: String) async -> String? {
+        guard let cli = passCLIPath else { return nil }
+
+        let vaultArg = vaultNameForShareId(shareId)
+
+        var args = ["item", "totp", "--item-id", itemId, "--output", "json"]
+        if let vault = vaultArg {
+            args += ["--vault-name", vault]
+        }
+
+        let result = await runProcess(executable: cli, arguments: args, input: nil)
+        guard result.exitCode == 0 else {
+            print("[AutofillStore] fetchTOTP failed: \(result.stderr)")
+            return nil
+        }
+
+        // pass-cli totp output may be plain text or JSON — handle both
+        let trimmed = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let data = trimmed.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let code = json["code"] as? String {
+            return code
+        }
+        // Fall back to raw output if not JSON
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    // MARK: - Save Credential
+
+    /// Save a new login item to the vault via `pass-cli item create login --from-template -`.
+    /// The template JSON is piped via stdin — password never appears in argv.
+    func saveCredential(
+        title: String,
+        username: String,
+        email: String,
+        password: String,
+        url: String,
+        vaultName targetVault: String
+    ) async -> Bool {
+        guard let cli = passCLIPath else { return false }
+
+        let template: [String: Any?] = [
+            "title": title,
+            "username": username.isEmpty ? nil : username,
+            "email": email.isEmpty ? nil : email,
+            "password": password,
+            "urls": [url]
+        ]
+
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: template),
+              let jsonString = String(data: jsonData, encoding: .utf8) else {
+            print("[AutofillStore] saveCredential: failed to serialize template")
+            return false
+        }
+
+        let result = await runProcess(
+            executable: cli,
+            arguments: ["item", "create", "login", "--vault-name", targetVault, "--from-template", "-"],
+            input: jsonString
+        )
+
+        if result.exitCode != 0 {
+            print("[AutofillStore] saveCredential failed: \(result.stderr)")
+            return false
+        }
+
+        // Invalidate the index so the next lookup picks up the new item
+        index.loadedAt = nil
+        print("[AutofillStore] Credential saved: \(title)")
+        return true
+    }
+
+    // MARK: - Vault Name Lookup
+
+    /// Returns the vault name for a given shareId by searching the index.
+    /// Falls back to the configured vaultName, then nil.
+    private func vaultNameForShareId(_ shareId: String) -> String? {
+        if let name = vaultName { return name }
+        return nil
+    }
+
+    // MARK: - Subprocess Helper
+
+    private struct ProcessResult {
+        let output: String
+        let stderr: String
+        let exitCode: Int32
+    }
+
+    /// Run an external process off the main thread, optionally piping `input` to stdin.
+    private nonisolated func runProcess(
+        executable: String,
+        arguments: [String],
+        input: String?
+    ) async -> ProcessResult {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: executable)
+                process.arguments = arguments
+
+                let stdoutPipe = Pipe()
+                let stderrPipe = Pipe()
+                process.standardOutput = stdoutPipe
+                process.standardError = stderrPipe
+
+                if let input {
+                    let stdinPipe = Pipe()
+                    process.standardInput = stdinPipe
+                    if let data = input.data(using: .utf8) {
+                        stdinPipe.fileHandleForWriting.write(data)
+                    }
+                    stdinPipe.fileHandleForWriting.closeFile()
+                }
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                } catch {
+                    continuation.resume(returning: ProcessResult(output: "", stderr: error.localizedDescription, exitCode: -1))
+                    return
+                }
+
+                let outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: outData, encoding: .utf8) ?? ""
+                let stderr = String(data: errData, encoding: .utf8) ?? ""
+
+                continuation.resume(returning: ProcessResult(
+                    output: output,
+                    stderr: stderr,
+                    exitCode: process.terminationStatus
+                ))
+            }
+        }
+    }
+
+    // MARK: - Host Normalization
+
+    /// Strip www. prefix and lowercase the host.
+    private func normalizeHost(_ host: String?) -> String? {
+        guard var h = host, !h.isEmpty else { return nil }
+        if h.lowercased().hasPrefix("www.") {
+            h = String(h.dropFirst(4))
+        }
+        return h.lowercased()
+    }
+}

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -240,12 +240,23 @@ final class AutofillStore: ObservableObject {
 
     // MARK: - JSON Parsing
 
-    /// Parse the JSON array returned by `pass-cli item list`.
+    /// Parse the JSON returned by `pass-cli item list`.
+    /// Handles both `{"items": [...]}` (current CLI) and bare `[...]` (legacy).
     /// Extracts metadata only — passwords and totp_uri are discarded after
     /// the hasTOTP boolean is derived.
     private func parseItemList(_ jsonString: String) -> [PassCredentialMeta] {
         guard let data = jsonString.data(using: .utf8),
-              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+              let json = try? JSONSerialization.jsonObject(with: data) else {
+            return []
+        }
+
+        let array: [[String: Any]]
+        if let dict = json as? [String: Any],
+           let items = dict["items"] as? [[String: Any]] {
+            array = items
+        } else if let items = json as? [[String: Any]] {
+            array = items
+        } else {
             return []
         }
 

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -118,8 +118,10 @@ final class AutofillStore: ObservableObject {
         }
 
         print("[AutofillStore] pass-cli not found — autofill disabled")
-        isUnavailable = true
-        unavailableReason = "pass-cli not found — install it or add it to PATH"
+        await MainActor.run {
+            isUnavailable = true
+            unavailableReason = "pass-cli not found — install it or add it to PATH"
+        }
     }
 
     // MARK: - Session Check
@@ -131,11 +133,15 @@ final class AutofillStore: ObservableObject {
         let result = await runProcess(executable: cli, arguments: ["test"], input: nil)
         if result.exitCode != 0 {
             print("[AutofillStore] pass-cli session expired")
-            isUnavailable = true
-            unavailableReason = "Proton Pass session expired — run `pass-cli login` in a terminal"
+            await MainActor.run {
+                isUnavailable = true
+                unavailableReason = "Proton Pass session expired — run `pass-cli login` in a terminal"
+            }
         } else {
-            isUnavailable = false
-            unavailableReason = ""
+            await MainActor.run {
+                isUnavailable = false
+                unavailableReason = ""
+            }
         }
     }
 
@@ -162,9 +168,18 @@ final class AutofillStore: ObservableObject {
 
         return index.items.filter { item in
             item.urls.contains { urlStr in
-                guard let url = URL(string: urlStr),
-                      let itemHost = normalizeHost(url.host) else { return false }
-                return itemHost == pageHost
+                // Try the URL as-is first
+                if let url = URL(string: urlStr),
+                   let itemHost = normalizeHost(url.host) {
+                    return itemHost == pageHost
+                }
+                // If host is nil and URL has no scheme, try prepending https://
+                if !urlStr.contains("://"),
+                   let url = URL(string: "https://\(urlStr)"),
+                   let itemHost = normalizeHost(url.host) {
+                    return itemHost == pageHost
+                }
+                return false
             }
         }
     }

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -54,7 +54,6 @@ private struct VaultIndex {
 /// Analogy: think of this like a DNS cache — it keeps a fast in-memory
 /// index of what's in the vault and only reaches out to the real store
 /// when it needs to resolve a specific secret.
-@MainActor
 final class AutofillStore: ObservableObject {
 
     // MARK: - Published State
@@ -371,7 +370,7 @@ final class AutofillStore: ObservableObject {
     }
 
     /// Run an external process off the main thread, optionally piping `input` to stdin.
-    private nonisolated func runProcess(
+    private func runProcess(
         executable: String,
         arguments: [String],
         input: String?

--- a/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
+++ b/macos/Sources/Features/Browser/Autofill/AutofillStore.swift
@@ -82,21 +82,44 @@ final class AutofillStore: ObservableObject {
     // MARK: - CLI Discovery
 
     private func discoverCLI() async {
-        let found = await runProcess(
-            executable: "/usr/bin/which",
-            arguments: ["pass-cli"],
+        // Finder-launched apps get a minimal PATH that excludes ~/.local/bin,
+        // /opt/homebrew/bin, etc. Check well-known locations directly instead
+        // of relying on `which`.
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            "\(home)/.local/bin/pass-cli",
+            "/opt/homebrew/bin/pass-cli",
+            "/usr/local/bin/pass-cli",
+            "\(home)/.cargo/bin/pass-cli"
+        ]
+
+        // Also try `which` via the user's login shell for non-standard locations
+        let whichResult = await runProcess(
+            executable: "/bin/zsh",
+            arguments: ["-l", "-c", "which pass-cli"],
             input: nil
         )
-        let trimmed = found.output.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty || found.exitCode != 0 {
-            print("[AutofillStore] pass-cli not found — autofill disabled")
-            isUnavailable = true
-            unavailableReason = "pass-cli not found in PATH"
+        let whichPath = whichResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        if whichResult.exitCode == 0, !whichPath.isEmpty {
+            passCLIPath = whichPath
+            print("[AutofillStore] pass-cli discovered via login shell at: \(whichPath)")
+            await checkSession()
             return
         }
-        passCLIPath = trimmed
-        print("[AutofillStore] pass-cli discovered at: \(trimmed)")
-        await checkSession()
+
+        // Fall back to well-known paths
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                passCLIPath = path
+                print("[AutofillStore] pass-cli discovered at: \(path)")
+                await checkSession()
+                return
+            }
+        }
+
+        print("[AutofillStore] pass-cli not found — autofill disabled")
+        isUnavailable = true
+        unavailableReason = "pass-cli not found — install it or add it to PATH"
     }
 
     // MARK: - Session Check

--- a/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
+++ b/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
@@ -7,7 +7,6 @@ import AppKit
 /// Per-tab autofill state machine. Receives WKScriptMessages dispatched
 /// by BrowserPaneModel, validates their origin, resolves matching
 /// credentials from the shared store, and drives the overlay UI state.
-@MainActor
 final class BrowserAutofillController: ObservableObject {
 
     // MARK: - Published UI State

--- a/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
+++ b/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
@@ -35,6 +35,10 @@ final class BrowserAutofillController: ObservableObject {
     /// Set to true after we fill a form, so submitDetected suppresses save.
     var autofillDidFill: Bool = false
 
+    /// CSS selectors extracted from the most recent formDetected message.
+    private var detectedUsernameSelector: String?
+    private var detectedPasswordSelector: String?
+
     /// Active TOTP clear timer.
     private var totpClearTimer: DispatchWorkItem?
 
@@ -104,18 +108,33 @@ final class BrowserAutofillController: ObservableObject {
         guard let webView,
               let pageURL = webView.url else { return }
 
+        // Extract form-specific selectors from the detection script.
+        // Use the first detected form (most pages have exactly one login form).
+        if let forms = body["forms"] as? [[String: Any]], let firstForm = forms.first {
+            detectedUsernameSelector = firstForm["usernameSelector"] as? String
+            detectedPasswordSelector = firstForm["passwordSelector"] as? String
+        } else {
+            detectedUsernameSelector = nil
+            detectedPasswordSelector = nil
+        }
+
         Task {
             // Re-check session if previously unavailable
             if store.isUnavailable {
                 await store.checkSession()
-                sessionExpired = store.isUnavailable
+                let stillUnavailable = store.isUnavailable
+                await MainActor.run {
+                    sessionExpired = stillUnavailable
+                }
                 // If still unavailable after re-check, bail out
-                if store.isUnavailable { return }
+                if stillUnavailable { return }
             }
 
             let matches = await store.findMatches(for: pageURL)
-            matchingCredentials = matches
-            showPrompt = !matches.isEmpty
+            await MainActor.run {
+                matchingCredentials = matches
+                showPrompt = !matches.isEmpty
+            }
         }
     }
 
@@ -166,7 +185,7 @@ final class BrowserAutofillController: ObservableObject {
                     webView.callAsyncJavaScript(
                         "return window.__tridentAutofillHelper.fill(selector, value)",
                         arguments: [
-                            "selector": "input[autocomplete=\"username\"], input[type=\"email\"], input[type=\"text\"]",
+                            "selector": self.detectedUsernameSelector ?? "input[autocomplete=\"username\"], input[type=\"email\"], input[type=\"text\"]",
                             "value": usernameValue
                         ],
                         in: nil,
@@ -176,7 +195,7 @@ final class BrowserAutofillController: ObservableObject {
                     webView.callAsyncJavaScript(
                         "return window.__tridentAutofillHelper.fill(selector, value)",
                         arguments: [
-                            "selector": "input[type=\"password\"]",
+                            "selector": self.detectedPasswordSelector ?? "input[type=\"password\"]",
                             "value": secret.password
                         ],
                         in: nil,
@@ -187,7 +206,7 @@ final class BrowserAutofillController: ObservableObject {
                 }
             }
 
-            autofillDidFill = true
+            await MainActor.run { autofillDidFill = true }
 
             if credential.hasTOTP {
                 await handleTOTP(shareId: credential.shareId, itemId: credential.itemId)
@@ -200,21 +219,20 @@ final class BrowserAutofillController: ObservableObject {
     private func handleTOTP(shareId: String, itemId: String) async {
         guard let code = await store.fetchTOTP(shareId: shareId, itemId: itemId) else { return }
 
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(code, forType: .string)
-
-        totpCode = code
-
-        totpClearTimer?.cancel()
-
-        let item = DispatchWorkItem { [weak self] in
+        await MainActor.run {
             NSPasteboard.general.clearContents()
-            DispatchQueue.main.async {
+            NSPasteboard.general.setString(code, forType: .string)
+
+            totpCode = code
+            totpClearTimer?.cancel()
+
+            let item = DispatchWorkItem { [weak self] in
+                NSPasteboard.general.clearContents()
                 self?.totpCode = nil
             }
+            totpClearTimer = item
+            DispatchQueue.main.asyncAfter(deadline: .now() + 30, execute: item)
         }
-        totpClearTimer = item
-        DispatchQueue.main.asyncAfter(deadline: .now() + 30, execute: item)
     }
 
     // MARK: - Save Credential

--- a/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
+++ b/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
@@ -105,10 +105,12 @@ final class BrowserAutofillController: ObservableObject {
               let pageURL = webView.url else { return }
 
         Task {
+            // Re-check session if previously unavailable
             if store.isUnavailable {
                 await store.checkSession()
                 sessionExpired = store.isUnavailable
-                return
+                // If still unavailable after re-check, bail out
+                if store.isUnavailable { return }
             }
 
             let matches = await store.findMatches(for: pageURL)

--- a/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
+++ b/macos/Sources/Features/Browser/Autofill/BrowserAutofillController.swift
@@ -1,0 +1,251 @@
+import Foundation
+import WebKit
+import AppKit
+
+// MARK: - BrowserAutofillController
+
+/// Per-tab autofill state machine. Receives WKScriptMessages dispatched
+/// by BrowserPaneModel, validates their origin, resolves matching
+/// credentials from the shared store, and drives the overlay UI state.
+@MainActor
+final class BrowserAutofillController: ObservableObject {
+
+    // MARK: - Published UI State
+
+    /// Credentials matching the current page URL, shown in the picker.
+    @Published var matchingCredentials: [PassCredentialMeta] = []
+    /// Show the credential picker overlay.
+    @Published var showPrompt: Bool = false
+    /// Show the save-new-password prompt.
+    @Published var showSave: Bool = false
+    /// Pending save state captured from the submit message.
+    @Published var pendingSaveUsername: String = ""
+    @Published var pendingSavePassword: String = ""
+    @Published var pendingSaveTitle: String = ""
+    /// TOTP toast: non-nil = show "TOTP copied" toast with this code hint.
+    @Published var totpCode: String?
+    /// True when AutofillStore reports session expired.
+    @Published var sessionExpired: Bool = false
+
+    // MARK: - Private State
+
+    private let store: AutofillStore
+    /// Weak reference to the WKWebView for JS injection.
+    private weak var webView: WKWebView?
+
+    /// Set to true after we fill a form, so submitDetected suppresses save.
+    var autofillDidFill: Bool = false
+
+    /// Active TOTP clear timer.
+    private var totpClearTimer: DispatchWorkItem?
+
+    // MARK: - Init
+
+    init(store: AutofillStore) {
+        self.store = store
+    }
+
+    /// Called by BrowserPaneModel once the WKWebView is created.
+    func attach(to webView: WKWebView) {
+        self.webView = webView
+    }
+
+    // MARK: - Message Dispatch
+
+    /// Entry point for messages arriving on the "autofill" handler.
+    /// All origin validation happens here before any action is taken.
+    func handleMessage(_ message: WKScriptMessage) {
+        // Only accept messages from the main frame
+        guard message.frameInfo.isMainFrame else {
+            print("[AutofillController] Ignored message from non-main frame")
+            return
+        }
+
+        guard let body = message.body as? [String: Any],
+              let kind = body["kind"] as? String else {
+            print("[AutofillController] Malformed message body")
+            return
+        }
+
+        // Validate that the message origin matches what WebKit reports
+        // for the webView's current URL — never trust page-reported URLs.
+        guard validateOrigin(message: message) else {
+            print("[AutofillController] Origin validation failed — ignoring message")
+            return
+        }
+
+        switch kind {
+        case "formDetected":
+            handleFormDetected(body: body)
+        case "submitDetected":
+            handleSubmitDetected(body: body)
+        case "fieldFocused":
+            break
+        default:
+            print("[AutofillController] Unknown message kind: \(kind)")
+        }
+    }
+
+    // MARK: - Origin Validation
+
+    private func validateOrigin(message: WKScriptMessage) -> Bool {
+        guard let webView,
+              let pageURL = webView.url else { return false }
+
+        let msgHost = message.frameInfo.securityOrigin.host
+        let pageHost = pageURL.host ?? ""
+
+        guard !msgHost.isEmpty, !pageHost.isEmpty else { return false }
+        return msgHost.lowercased() == pageHost.lowercased()
+    }
+
+    // MARK: - Form Detected Handler
+
+    private func handleFormDetected(body: [String: Any]) {
+        guard let webView,
+              let pageURL = webView.url else { return }
+
+        Task {
+            if store.isUnavailable {
+                await store.checkSession()
+                sessionExpired = store.isUnavailable
+                return
+            }
+
+            let matches = await store.findMatches(for: pageURL)
+            matchingCredentials = matches
+            showPrompt = !matches.isEmpty
+        }
+    }
+
+    // MARK: - Submit Detected Handler
+
+    private func handleSubmitDetected(body: [String: Any]) {
+        // If we just filled this form ourselves, suppress the save prompt
+        guard !autofillDidFill else {
+            autofillDidFill = false
+            return
+        }
+
+        guard let isNewPassword = body["isNewPassword"] as? Bool, isNewPassword else { return }
+
+        let username = body["username"] as? String ?? ""
+        let password = body["password"] as? String ?? ""
+        guard !password.isEmpty else { return }
+
+        let domain = webView?.url?.host ?? "Unknown site"
+
+        pendingSaveUsername = username
+        pendingSavePassword = password
+        pendingSaveTitle = domain
+        showSave = true
+    }
+
+    // MARK: - Fill Orchestration
+
+    /// Called when the user selects a credential from the picker.
+    func fill(credential: PassCredentialMeta) {
+        guard let webView else { return }
+        showPrompt = false
+
+        Task {
+            guard let secret = await store.fetchCredential(
+                shareId: credential.shareId,
+                itemId: credential.itemId
+            ) else {
+                print("[AutofillController] fetchCredential returned nil")
+                return
+            }
+
+            let usernameValue = secret.email.isEmpty ? secret.username : secret.email
+
+            // Fill username via callAsyncJavaScript with arguments (no string interpolation)
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                DispatchQueue.main.async {
+                    webView.callAsyncJavaScript(
+                        "return window.__tridentAutofillHelper.fill(selector, value)",
+                        arguments: [
+                            "selector": "input[autocomplete=\"username\"], input[type=\"email\"], input[type=\"text\"]",
+                            "value": usernameValue
+                        ],
+                        in: nil,
+                        in: .defaultClient
+                    ) { _ in }
+
+                    webView.callAsyncJavaScript(
+                        "return window.__tridentAutofillHelper.fill(selector, value)",
+                        arguments: [
+                            "selector": "input[type=\"password\"]",
+                            "value": secret.password
+                        ],
+                        in: nil,
+                        in: .defaultClient
+                    ) { _ in
+                        continuation.resume()
+                    }
+                }
+            }
+
+            autofillDidFill = true
+
+            if credential.hasTOTP {
+                await handleTOTP(shareId: credential.shareId, itemId: credential.itemId)
+            }
+        }
+    }
+
+    // MARK: - TOTP Handling
+
+    private func handleTOTP(shareId: String, itemId: String) async {
+        guard let code = await store.fetchTOTP(shareId: shareId, itemId: itemId) else { return }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(code, forType: .string)
+
+        totpCode = code
+
+        totpClearTimer?.cancel()
+
+        let item = DispatchWorkItem { [weak self] in
+            NSPasteboard.general.clearContents()
+            DispatchQueue.main.async {
+                self?.totpCode = nil
+            }
+        }
+        totpClearTimer = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30, execute: item)
+    }
+
+    // MARK: - Save Credential
+
+    func saveCredential(title: String, username: String, vaultName: String) {
+        showSave = false
+        let password = pendingSavePassword
+        let url = webView?.url?.absoluteString ?? ""
+
+        Task {
+            let success = await store.saveCredential(
+                title: title,
+                username: username,
+                email: "",
+                password: password,
+                url: url,
+                vaultName: vaultName
+            )
+            if !success {
+                print("[AutofillController] saveCredential failed")
+            }
+        }
+    }
+
+    // MARK: - Dismiss
+
+    func dismissPrompt() {
+        showPrompt = false
+        matchingCredentials = []
+    }
+
+    func dismissSave() {
+        showSave = false
+    }
+}

--- a/macos/Sources/Features/Browser/Autofill/autofill-detection.js
+++ b/macos/Sources/Features/Browser/Autofill/autofill-detection.js
@@ -1,0 +1,149 @@
+(function () {
+  'use strict';
+
+  if (window.__tridentAutofillDetectionActive) return;
+  window.__tridentAutofillDetectionActive = true;
+
+  function postToNative(msg) {
+    try {
+      window.webkit.messageHandlers.autofill.postMessage(msg);
+    } catch (e) {}
+  }
+
+  function isVisible(el) {
+    return el.offsetParent !== null || el.offsetWidth > 0 || el.offsetHeight > 0;
+  }
+
+  var USERNAME_SELECTORS = [
+    'input[autocomplete="username"]',
+    'input[autocomplete="email"]',
+    'input[type="email"]',
+    'input[type="text"]'
+  ];
+
+  function findUsernameField(passwordField) {
+    var root = passwordField.closest('form') || document.body;
+    var candidates = Array.from(root.querySelectorAll(USERNAME_SELECTORS.join(',')));
+    candidates = candidates.filter(function (c) {
+      return !!(c.compareDocumentPosition(passwordField) & Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+    return candidates.length > 0 ? candidates[candidates.length - 1] : null;
+  }
+
+  function buildSelector(el) {
+    if (el.id) return '#' + CSS.escape(el.id);
+    if (el.name) return el.tagName.toLowerCase() + '[name="' + el.name + '"]';
+    var parts = [];
+    var node = el;
+    while (node && node !== document.body) {
+      var parent = node.parentElement;
+      if (!parent) break;
+      var siblings = Array.from(parent.children).filter(function (c) {
+        return c.tagName === node.tagName;
+      });
+      var idx = siblings.indexOf(node) + 1;
+      parts.unshift(node.tagName.toLowerCase() + ':nth-of-type(' + idx + ')');
+      node = parent;
+    }
+    return parts.join(' > ');
+  }
+
+  function isNewPasswordField(el) {
+    return el.getAttribute('autocomplete') === 'new-password';
+  }
+
+  function scanForms() {
+    var passwordFields = Array.from(document.querySelectorAll('input[type="password"]'))
+      .filter(isVisible);
+
+    if (passwordFields.length === 0) return null;
+
+    var forms = [];
+    var seen = new Set();
+    var formIndex = 0;
+
+    passwordFields.forEach(function (pwField) {
+      var root = pwField.closest('form') || document.body;
+      if (seen.has(root)) return;
+      seen.add(root);
+
+      var usernameField = findUsernameField(pwField);
+      var hasNewPassword = isNewPasswordField(pwField);
+
+      var allPasswords = Array.from(root.querySelectorAll('input[type="password"]')).filter(isVisible);
+      if (allPasswords.length >= 2) {
+        hasNewPassword = true;
+      }
+
+      var form = {
+        formId: 'auto-' + formIndex++,
+        hasPassword: true,
+        hasNewPassword: hasNewPassword,
+        usernameSelector: usernameField ? buildSelector(usernameField) : null,
+        passwordSelector: buildSelector(pwField)
+      };
+
+      forms.push(form);
+
+      [usernameField, pwField].forEach(function (field) {
+        if (!field) return;
+        if (field.__tridentFocusTracked) return;
+        field.__tridentFocusTracked = true;
+        field.addEventListener('focus', function () {
+          postToNative({ kind: 'fieldFocused', formId: form.formId });
+        });
+      });
+    });
+
+    return forms.length > 0 ? forms : null;
+  }
+
+  var scanTimer = null;
+
+  function scheduleScan() {
+    clearTimeout(scanTimer);
+    scanTimer = setTimeout(function () {
+      var forms = scanForms();
+      if (forms) {
+        postToNative({ kind: 'formDetected', forms: forms });
+      }
+    }, 500);
+  }
+
+  function attachSubmitListeners() {
+    document.querySelectorAll('form').forEach(function (form) {
+      if (form.__tridentSubmitTracked) return;
+      form.__tridentSubmitTracked = true;
+
+      form.addEventListener('submit', function () {
+        var pwField = form.querySelector('input[type="password"]');
+        if (!pwField || !pwField.value) return;
+
+        var allPasswords = Array.from(form.querySelectorAll('input[type="password"]')).filter(isVisible);
+        var isNewPassword = allPasswords.length >= 2 ||
+          allPasswords.some(function (f) { return f.getAttribute('autocomplete') === 'new-password'; });
+
+        var usernameField = findUsernameField(pwField);
+        var username = usernameField ? usernameField.value : '';
+
+        postToNative({
+          kind: 'submitDetected',
+          username: username,
+          password: pwField.value,
+          isNewPassword: isNewPassword
+        });
+      });
+    });
+  }
+
+  var observer = new MutationObserver(function () {
+    scheduleScan();
+    attachSubmitListeners();
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  scheduleScan();
+  attachSubmitListeners();
+
+})();

--- a/macos/Sources/Features/Browser/Autofill/autofill-fill.js
+++ b/macos/Sources/Features/Browser/Autofill/autofill-fill.js
@@ -1,0 +1,35 @@
+// Fill helper — injected into WKContentWorld.defaultClient.
+// Isolated from page JavaScript so page scripts cannot intercept
+// our fill function or its arguments (though filled DOM values
+// remain visible to all worlds — accepted trade-off).
+
+window.__tridentAutofillHelper = {
+  /**
+   * Fill a single input field identified by `selector` with `value`.
+   * Uses the native HTMLInputElement setter so that React, Angular, and
+   * other frameworks that replace the property descriptor pick up the change.
+   * Fires both 'input' and 'change' events to trigger framework listeners.
+   *
+   * @param {string} selector - CSS selector for the target input
+   * @param {string} value    - Value to set
+   * @returns {boolean} true if the field was found and filled
+   */
+  fill: function (selector, value) {
+    var el = document.querySelector(selector);
+    if (!el) return false;
+
+    // Use the native setter, bypassing any framework wrappers on the
+    // prototype — same technique used by Cypress, Playwright, etc.
+    var nativeSetter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value'
+    ).set;
+    nativeSetter.call(el, value);
+
+    // Dispatch input and change events so React/Angular/Vue re-render
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+
+    return true;
+  }
+};

--- a/macos/Sources/Features/Browser/BrowserPaneModel.swift
+++ b/macos/Sources/Features/Browser/BrowserPaneModel.swift
@@ -42,6 +42,12 @@ class BrowserPaneModel: NSObject, ObservableObject {
     /// HAR recorder for capturing HTTP request/response metadata.
     let harRecorder: BrowserHARRecorder
 
+    /// Per-tab autofill controller. Nil when autofill is disabled via config.
+    let autofillController: BrowserAutofillController?
+
+    /// Whether autofill is active for this tab (config-driven).
+    let autofillEnabled: Bool
+
     /// The WKWebView instance. Created lazily on first access so the proxy
     /// relay is guaranteed to be running before the web view configures its
     /// proxy settings.
@@ -53,7 +59,7 @@ class BrowserPaneModel: NSObject, ObservableObject {
         let recorder = BrowserHARRecorder()
 
         // Start a local proxy relay
-        var relay: BrowserProxyRelay? = nil
+        var relay: BrowserProxyRelay?
         let r = BrowserProxyRelay()
         r.upstreamProxy = proxyURL
         r.harRecorder = recorder
@@ -94,7 +100,9 @@ class BrowserPaneModel: NSObject, ObservableObject {
         tlsStrict: Bool = true,
         sharedRelay: BrowserProxyRelay?,
         ownsRelay: Bool,
-        harRecorder: BrowserHARRecorder
+        harRecorder: BrowserHARRecorder,
+        autofillStore: AutofillStore? = nil,
+        autofillEnabled: Bool = false
     ) {
         self.proxyURL = proxyURL
         self.proxyCertPath = proxyCertPath
@@ -102,6 +110,12 @@ class BrowserPaneModel: NSObject, ObservableObject {
         self.proxyRelay = sharedRelay
         self.ownsRelay = ownsRelay
         self.harRecorder = harRecorder
+        self.autofillEnabled = autofillEnabled
+        if autofillEnabled, let store = autofillStore {
+            self.autofillController = BrowserAutofillController(store: store)
+        } else {
+            self.autofillController = nil
+        }
         super.init()
     }
 
@@ -208,6 +222,28 @@ class BrowserPaneModel: NSObject, ObservableObject {
     })();
     """
 
+    /// JavaScript injected at document end (main frame only, page world) for
+    /// form detection + submit capture. Loaded from the bundled resource file.
+    static let autofillDetectionScript: String = {
+        guard let url = Bundle.main.url(forResource: "autofill-detection", withExtension: "js"),
+              let source = try? String(contentsOf: url, encoding: .utf8) else {
+            print("[BrowserPane] autofill-detection.js not found in bundle")
+            return ""
+        }
+        return source
+    }()
+
+    /// JavaScript injected at document end (defaultClient world) for safe field fill.
+    /// Loaded from the bundled resource file.
+    static let autofillFillScript: String = {
+        guard let url = Bundle.main.url(forResource: "autofill-fill", withExtension: "js"),
+              let source = try? String(contentsOf: url, encoding: .utf8) else {
+            print("[BrowserPane] autofill-fill.js not found in bundle")
+            return ""
+        }
+        return source
+    }()
+
     /// Creates and configures the WKWebView. Called once via lazy initialization.
     /// NOTE: This must not be called during init — proxyRelay must be set up first.
     private func createWebView() -> WKWebView {
@@ -245,12 +281,40 @@ class BrowserPaneModel: NSObject, ObservableObject {
         )
         contentController.addUserScript(harScript)
 
+        // Register autofill scripts and message handler (when enabled)
+        if autofillEnabled, !Self.autofillDetectionScript.isEmpty {
+            // Handler: routes "autofill" messages to the per-tab controller
+            contentController.add(WeakScriptMessageHandler(self), name: "autofill")
+
+            // Detection script: runs in page world at document end, main frame only
+            let detectionScript = WKUserScript(
+                source: Self.autofillDetectionScript,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+            contentController.addUserScript(detectionScript)
+
+            // Fill helper: runs in defaultClient world at document end
+            if !Self.autofillFillScript.isEmpty {
+                let fillScript = WKUserScript(
+                    source: Self.autofillFillScript,
+                    injectionTime: .atDocumentEnd,
+                    forMainFrameOnly: true,
+                    in: .defaultClient
+                )
+                contentController.addUserScript(fillScript)
+            }
+        }
+
         let wv = WKWebView(frame: .zero, configuration: config)
         wv.navigationDelegate = self
         wv.allowsBackForwardNavigationGestures = true
 
         setupObservations(for: wv)
         self.inspectorOverlay = BrowserInspectorOverlay(webView: wv)
+
+        // Attach autofill controller to the web view
+        autofillController?.attach(to: wv)
 
         return wv
     }
@@ -523,38 +587,46 @@ extension BrowserPaneModel: WKNavigationDelegate {
 
 extension BrowserPaneModel: WKScriptMessageHandler {
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard message.name == "harLog",
-              let body = message.body as? [String: Any],
-              harRecorder.isRecording else { return }
+        switch message.name {
+        case "harLog":
+            guard let body = message.body as? [String: Any],
+                  harRecorder.isRecording else { return }
 
-        let method = body["method"] as? String ?? "GET"
-        let url = body["url"] as? String ?? ""
-        let status = body["status"] as? Int ?? 0
-        let statusText = body["statusText"] as? String ?? ""
-        let duration = (body["duration"] as? Double ?? 0) / 1000.0
+            let method = body["method"] as? String ?? "GET"
+            let url = body["url"] as? String ?? ""
+            let status = body["status"] as? Int ?? 0
+            let statusText = body["statusText"] as? String ?? ""
+            let duration = (body["duration"] as? Double ?? 0) / 1000.0
 
-        var reqHeaders: [(name: String, value: String)] = []
-        if let headers = body["requestHeaders"] as? [String: String] {
-            reqHeaders = headers.map { (name: $0.key, value: $0.value) }
+            var reqHeaders: [(name: String, value: String)] = []
+            if let headers = body["requestHeaders"] as? [String: String] {
+                reqHeaders = headers.map { (name: $0.key, value: $0.value) }
+            }
+            var respHeaders: [(name: String, value: String)] = []
+            if let headers = body["responseHeaders"] as? [String: String] {
+                respHeaders = headers.map { (name: $0.key, value: $0.value) }
+            }
+
+            harRecorder.append(HAREntry(
+                startedDateTime: Date(),
+                method: method,
+                url: url,
+                httpVersion: "HTTP/1.1",
+                requestHeaders: reqHeaders,
+                responseStatus: status,
+                responseStatusText: statusText,
+                responseHeaders: respHeaders,
+                responseBodySize: 0,
+                timings: HARTimings(connect: 0, send: 0, wait: duration, receive: 0),
+                source: .jsIntercept
+            ))
+
+        case "autofill":
+            autofillController?.handleMessage(message)
+
+        default:
+            break
         }
-        var respHeaders: [(name: String, value: String)] = []
-        if let headers = body["responseHeaders"] as? [String: String] {
-            respHeaders = headers.map { (name: $0.key, value: $0.value) }
-        }
-
-        harRecorder.append(HAREntry(
-            startedDateTime: Date(),
-            method: method,
-            url: url,
-            httpVersion: "HTTP/1.1",
-            requestHeaders: reqHeaders,
-            responseStatus: status,
-            responseStatusText: statusText,
-            responseHeaders: respHeaders,
-            responseBodySize: 0,
-            timings: HARTimings(connect: 0, send: 0, wait: duration, receive: 0),
-            source: .jsIntercept
-        ))
     }
 }
 

--- a/macos/Sources/Features/Browser/BrowserPaneView.swift
+++ b/macos/Sources/Features/Browser/BrowserPaneView.swift
@@ -79,9 +79,23 @@ struct BrowserPaneView: View {
                         .progressViewStyle(.linear)
                 }
 
-                // Web content — .id forces view swap when switching tabs
-                BrowserWebView(model: model, onBrowserFocused: onBrowserFocused)
-                    .id(model.id)
+                // Web content with autofill overlay
+                ZStack(alignment: .top) {
+                    BrowserWebView(model: model, onBrowserFocused: onBrowserFocused)
+                        .id(model.id)
+
+                    if let controller = model.autofillController {
+                        AutofillOverlayView(
+                            controller: controller,
+                            availableVaults: ["Personal"]
+                        )
+                        .allowsHitTesting(
+                            controller.showPrompt ||
+                            controller.showSave ||
+                            controller.sessionExpired
+                        )
+                    }
+                }
 
                 // JS Console panel
                 if model.jsConsoleVisible {

--- a/macos/Sources/Features/Browser/BrowserTabManager.swift
+++ b/macos/Sources/Features/Browser/BrowserTabManager.swift
@@ -20,11 +20,15 @@ class BrowserTabManager: ObservableObject {
     let harRecorder: BrowserHARRecorder
     private(set) var proxyRelay: BrowserProxyRelay?
     private(set) var socketServer: BrowserSocketServer?
+    /// Shared autofill vault index and pass-cli interface, nil when disabled.
+    private(set) var autofillStore: AutofillStore?
 
     /// Config values forwarded to new tab models.
     private let proxyURL: String?
     private let proxyCertPath: String?
     private let tlsStrict: Bool
+    private let autofillEnabled: Bool
+    private let autofillVault: String?
 
     /// Combine subscriptions for forwarding child objectWillChange.
     private var childCancellables: [UUID: AnyCancellable] = [:]
@@ -35,11 +39,22 @@ class BrowserTabManager: ObservableObject {
         return tabs[activeTabIndex].model
     }
 
-    init(proxyURL: String? = nil, proxyCertPath: String? = nil, tlsStrict: Bool = true) {
+    init(
+        proxyURL: String? = nil,
+        proxyCertPath: String? = nil,
+        tlsStrict: Bool = true,
+        autofillEnabled: Bool = false,
+        autofillVault: String? = nil
+    ) {
         self.proxyURL = proxyURL
         self.proxyCertPath = proxyCertPath
         self.tlsStrict = tlsStrict
+        self.autofillEnabled = autofillEnabled
+        self.autofillVault = autofillVault
         self.harRecorder = BrowserHARRecorder()
+        if autofillEnabled {
+            self.autofillStore = AutofillStore(vaultName: autofillVault)
+        }
 
         // Start shared proxy relay
         let relay = BrowserProxyRelay()
@@ -66,7 +81,7 @@ class BrowserTabManager: ObservableObject {
         }
 
         // Create the first tab
-        let _ = addTab()
+        _ = addTab()
     }
 
     deinit {
@@ -92,7 +107,9 @@ class BrowserTabManager: ObservableObject {
             tlsStrict: tlsStrict,
             sharedRelay: proxyRelay,
             ownsRelay: false,
-            harRecorder: harRecorder
+            harRecorder: harRecorder,
+            autofillStore: autofillStore,
+            autofillEnabled: autofillEnabled
         )
         if let url = url {
             model.navigate(to: url)

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -681,6 +681,23 @@ extension Ghostty {
             return v
         }
 
+        var browserAutofill: Bool {
+            guard let config = self.config else { return true }
+            var v = true
+            let key = "browser-autofill"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
+
+        var browserAutofillVault: String? {
+            guard let config = self.config else { return nil }
+            var v: UnsafePointer<Int8>?
+            let key = "browser-autofill-vault"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return nil }
+            guard let ptr = v else { return nil }
+            return String(cString: ptr)
+        }
+
         /// Get popup profile configurations from the Zig config system.
         /// Returns a dictionary of profile name -> PopupProfileConfig.
         var popupProfiles: [String: PopupController.PopupProfileConfig] {

--- a/macos/Sources/Ghostty/Surface View/BrowsableSurface.swift
+++ b/macos/Sources/Ghostty/Surface View/BrowsableSurface.swift
@@ -72,7 +72,9 @@ extension Ghostty {
                 let manager = BrowserTabManager(
                     proxyURL: ghostty.config.browserProxy,
                     proxyCertPath: ghostty.config.browserProxyCert,
-                    tlsStrict: ghostty.config.browserTlsStrict
+                    tlsStrict: ghostty.config.browserTlsStrict,
+                    autofillEnabled: ghostty.config.browserAutofill,
+                    autofillVault: ghostty.config.browserAutofillVault
                 )
                 manager.onLastTabClosed = { [weak surfaceView] in
                     guard let surfaceView else { return }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3893,6 +3893,17 @@ term: []const u8 = "xterm-ghostty",
 /// NOT affect terminal connections — only the embedded browser.
 @"browser-tls-strict": bool = true,
 
+/// Enable Proton Pass autofill in browser panes. When true, Trident
+/// injects form-detection JavaScript and offers to fill credentials
+/// from pass-cli. Set to false to disable all autofill functionality.
+/// Only effective when the browser pane feature is enabled.
+@"browser-autofill": bool = true,
+
+/// Restrict autofill to a single Proton Pass vault by name
+/// (e.g., "Personal"). When null, credentials are loaded from all
+/// vaults. Only effective when `browser-autofill` is true.
+@"browser-autofill-vault": ?[:0]const u8 = null,
+
 /// This is set by the CLI parser for deinit.
 _arena: ?ArenaAllocator = null,
 


### PR DESCRIPTION
## Summary
- split the existing autofill implementation into a reviewable foundation layer
- keep the issue-specific fixes focused in #77
- preserve a clean review stack after the shared macOS test support landed in `main`

## Notes
- Replacement PR for the original stacked branch after #79 was squash-merged into `main`.
- This remains the base branch for #77 until that branch is rebased as the final step in the queue.

## macOS Test Plan
- `xcodebuild test -project macos/Ghostty.xcodeproj -scheme Ghostty -configuration Debug SYMROOT=macos/build -skip-testing GhosttyUITests -only-testing:GhosttyTests/BrowserAutofillTests` (verified from stacked `codex/autofill-issues`)

## Linux Test Plan
- Not run; browser autofill implementation is macOS-only.